### PR TITLE
chore: add Dependabot and auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Grouped into a single PR so related action bumps land together rather than
+  # as a stream of separate PRs. Auto-merge handles them once CI passes.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,21 @@
+name: Auto merge
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+jobs:
+  auto-merge:
+    # The reusable workflow cannot grant itself more than the caller has, and
+    # the org default for GITHUB_TOKEN is read-only — so declare it here.
+    permissions:
+      contents: write
+      pull-requests: write
+    # Only the conclusion is checked, not workflow_run.event: a same-repo
+    # branch (which is how Dependabot pushes) triggers CI as 'push', not
+    # 'pull_request', so gating on the event silently skipped every run. The
+    # reusable workflow looks up the PR and enforces the author allow-list,
+    # which is the actual safety gate; a run with no open PR just no-ops.
+    if: github.event.workflow_run.conclusion == 'success'
+    uses: drumandbytes/reusable-actions/.github/workflows/auto-merge.yml@v1


### PR DESCRIPTION
## Summary
Adds Dependabot (`gomod` + `github-actions`) and the reusable auto-merge workflow already used across other repos, gated on the existing `CI` workflow's success.

## Test plan
- [x] YAML validated
- [ ] Confirm a Dependabot PR gets auto-merged once CI passes