### PR TITLE
chore: use the shared Go CI reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,48 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-go@v7
-        with:
-          go-version: "1.26"
-
-      - name: Build
-        run: go build ./...
-
-      - name: Vet
-        run: go vet ./...
-
-      - name: gofmt
-        run: |
-          unformatted=$(gofmt -l .)
-          if [ -n "$unformatted" ]; then
-            echo "The following files are not gofmt-formatted:"
-            echo "$unformatted"
-            echo "Run 'gofmt -w .' locally and commit the result."
-            exit 1
-          fi
-
-      - name: Test
-        run: go test -race ./...
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-go@v7
-        with:
-          go-version: "1.26"
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          # v6 of this action resolved "latest" to an old golangci-lint
-          # v1.x binary (built with go1.24), which then refused to lint a
-          # go1.26 module - v9 correctly resolves "latest" to the current
-          # v2.x line (verified locally: v2.13.1, built with go1.26.7).
-          version: latest
+  ci:
+    uses: drumandbytes/reusable-actions/.github/workflows/go-ci.yml@v1
+    with:
+      go-version: "1.26"
+      test-race: true


### PR DESCRIPTION
## Summary
Replaces the hand-rolled build/vet/gofmt/test/golangci-lint jobs with drumandbytes/reusable-actions' new `go-ci.yml`, keeping the same Go version and `-race` flag this repo already used.

## Test plan
- [x] actionlint clean
- [ ] Confirm CI passes on this PR