### PR TITLE
Broker data: Internet Brands wants the specific site named, exclude from send

### DIFF
--- a/data/brokers.yaml
+++ b/data/brokers.yaml
@@ -3205,6 +3205,7 @@ brokers:
       opt_out_url: https://www.internetbrands.com/privacy/privacy-contact-form.php
       region: us
       category: marketing
+      notes: 'Reply (2026-09-02) will not proceed until you specify which Internet Brands website the erasure request concerns - MH Sub I, LLC runs many separate consumer sites (WebMD, Nolo, Martindale-Hubbell, CarsDirect, Fodor''s, etc.). Excluded from bulk send; needs a manual reply that either names the specific site(s) used or asserts the Art. 17 request covers all personal data MH Sub I, LLC holds as controller.'
     - id: mightyrep
       name: Mightyrep
       email: privacy@mightyrep.com


### PR DESCRIPTION
## What

Internet Brands (`MH Sub I, LLC` / broker `mh-sub-i`) replied to a GDPR Art. 17 erasure request (2026-09-02) refusing to proceed until the requester names which specific Internet Brands website the request concerns — a controller deflection, since MH Sub I runs many separate consumer sites (WebMD, Nolo, Martindale-Hubbell, CarsDirect, Fodor's, etc.).

- Adds a dated `notes:` line to the `mh-sub-i` entry recording the requirement, matching the existing `Reply (date) ...` convention.
- Email/website/category unchanged — they do process email, they just want the site named.

The matching `options.excluded_brokers: [mh-sub-i]` change lives in the user's local `~/.eraser/config.yaml` (outside the repo), so bulk `send` skips it pending a manual, tailored reply.

## Verification

`go build` / `go vet ./...` / `go test ./...` all pass. `send --dry-run` no longer includes the broker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)