### PR TITLE
release: publish a Homebrew cask

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,20 @@ jobs:
         with:
           go-version: "1.26"
 
+      # Short-lived token for the dnb-robot GitHub App, scoped to this repo (to
+      # publish the release) and homebrew-tap (for GoReleaser to push the
+      # updated Formula). The default GITHUB_TOKEN can't write to another repo.
+      - uses: actions/create-github-app-token@v2
+        id: app_token
+        with:
+          app-id: 4773076
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+          owner: drumandbytes
+          repositories: eraser,homebrew-tap
+
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ archives:
     formats: [tar.gz]
     format_overrides:
       - goos: windows
-        formats: [zip]
+        formats: [zip, binary]
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
     files:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,3 +54,23 @@ release:
     name: eraser
   draft: false
   prerelease: auto
+
+# macOS: brew install drumandbytes/homebrew-tap/eraser
+# (Homebrew strips the Gatekeeper quarantine on cask install, so no xattr dance.)
+homebrew_casks:
+  - name: eraser
+    repository:
+      owner: drumandbytes
+      name: homebrew-tap
+      branch: main
+    directory: Casks
+    homepage: "https://eraser.drumandbytes.dev"
+    description: "Send data removal requests to data brokers"
+    license: "MIT"
+    commit_author:
+      name: dnb-robot[bot]
+      email: 4773076+dnb-robot[bot]@users.noreply.github.com
+    caveats: |
+      Config lives at ~/.eraser/config.yaml. Start with:
+        eraser serve      # web UI at http://localhost:8080
+      `eraser fill` / `eraser confirm` also need Chrome installed.

--- a/README.md
+++ b/README.md
@@ -37,17 +37,22 @@ If you're not comfortable with command-line tools, Eraser has a visual interface
 
 **Step 1: Get Eraser**
 
-**macOS / Linux with Homebrew:**
+**macOS (Homebrew):**
 
 ```bash
 brew install drumandbytes/homebrew-tap/eraser
 ```
 
-(Homebrew clears the Gatekeeper quarantine for you.)
+Homebrew clears the Gatekeeper quarantine for you. (Homebrew also runs on
+Linux, but cask support there is limited — Linux users, use the tarball below.)
 
-**Prebuilt binary:** download the archive for your OS from the
-[Releases page](https://github.com/drumandbytes/eraser/releases), unpack it, and
-run `./eraser` — nothing to install, the broker list is baked in.
+**Prebuilt binary:** grab your OS's file from the
+[Releases page](https://github.com/drumandbytes/eraser/releases) — the broker
+list is baked in, nothing to install:
+
+- **Windows** — `..._windows_amd64.exe` (run it directly) or the `.zip` (also has
+  the README and `config.example.yaml`).
+- **macOS / Linux** — `..._<os>_<arch>.tar.gz`; `tar xzf` it and run `./eraser`.
 
 - **macOS:** the binary is unsigned, so Gatekeeper will block it on first run.
   Either right-click it → *Open* → *Open*, or run

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ If you're not comfortable with command-line tools, Eraser has a visual interface
 
 **Step 1: Get Eraser**
 
-**macOS (Homebrew):**
+**Homebrew (macOS, and Linux where cask support is available):**
 
 ```bash
 brew install drumandbytes/homebrew-tap/eraser
 ```
 
-Homebrew clears the Gatekeeper quarantine for you. (Homebrew also runs on
-Linux, but cask support there is limited — Linux users, use the tarball below.)
+On macOS this also clears the Gatekeeper quarantine for you. If `brew` on your
+Linux setup doesn't do casks, use the tarball below.
 
 **Prebuilt binary:** grab your OS's file from the
 [Releases page](https://github.com/drumandbytes/eraser/releases) — the broker

--- a/README.md
+++ b/README.md
@@ -37,9 +37,17 @@ If you're not comfortable with command-line tools, Eraser has a visual interface
 
 **Step 1: Get Eraser**
 
-**Prebuilt binary (easiest):** download the archive for your OS from the
+**macOS / Linux with Homebrew:**
+
+```bash
+brew install drumandbytes/homebrew-tap/eraser
+```
+
+(Homebrew clears the Gatekeeper quarantine for you.)
+
+**Prebuilt binary:** download the archive for your OS from the
 [Releases page](https://github.com/drumandbytes/eraser/releases), unpack it, and
-you're done — the broker list is baked in.
+run `./eraser` — nothing to install, the broker list is baked in.
 
 - **macOS:** the binary is unsigned, so Gatekeeper will block it on first run.
   Either right-click it → *Open* → *Open*, or run

--- a/cmd/eraser/main.go
+++ b/cmd/eraser/main.go
@@ -61,6 +61,9 @@ requests to data brokers, helping you protect your privacy.
 It supports GDPR, CCPA, and generic removal request templates, and can
 send via Gmail SMTP.`,
 	}
+	// So a standalone binary (no LICENSE file alongside it) still points at
+	// the MIT terms it ships under.
+	rootCmd.SetVersionTemplate("eraser {{.Version}}\nMIT licensed - https://github.com/drumandbytes/eraser/blob/main/LICENSE\n")
 
 	// Global flags
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.eraser/config.yaml)")


### PR DESCRIPTION
`brew install drumandbytes/homebrew-tap/eraser` after this.

- `.goreleaser.yaml`: `homebrew_casks` (the old `brews` is deprecated in GoReleaser v2). On each release it writes `Casks/eraser.rb` to `drumandbytes/homebrew-tap`. Covers macOS **and** Linuxbrew. Homebrew clears the Gatekeeper quarantine on cask install, so cask users skip the `xattr` step.
- `release.yml`: the `goreleaser` job mints a short-lived **dnb-robot** App token scoped to `eraser` + `homebrew-tap` (the default `GITHUB_TOKEN` can't write to another repo). `AUTOMATION_APP_PRIVATE_KEY` is already an org secret with `ALL` visibility.
- README: `brew install` as the first option.

Verified with `goreleaser check` + `--snapshot` — the cask generates correctly.

### One-time manual step before the next release
1. Create the tap repo (I was blocked from doing this):
   ```
   gh repo create drumandbytes/homebrew-tap --public \
     --description "Homebrew tap for drumandbytes tools" --add-readme
   ```
2. Ensure the **dnb-robot** GitHub App has access to `homebrew-tap` (automatic if it's installed org-wide on "All repositories"; otherwise add it under Org Settings → GitHub Apps → dnb-robot → Repository access).

The tap starts empty; the first `Release` run after this merges will populate `Casks/eraser.rb`.