### PR TITLE
web: fix confidence shown as "0.85%" in the response list

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -194,6 +194,10 @@ func (s *Server) parseTemplates() (map[string]*template.Template, error) {
 		"add": func(a, b int) int {
 			return a + b
 		},
+		// percent formats a 0..1 confidence score as a whole-number percentage.
+		"percent": func(f float64) string {
+			return fmt.Sprintf("%.0f%%", f*100)
+		},
 		// dict builds a map from alternating key/value args so a partial can be
 		// invoked with more than one parameter, e.g.
 		// {{template "partials/broker-row.html" (dict "Broker" . "IDPrefix" "mobile-")}}

--- a/internal/web/templates/partials/response-list.html
+++ b/internal/web/templates/partials/response-list.html
@@ -62,7 +62,7 @@
             <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
             </svg>
-            Confidence: {{.Confidence}}% - Manual review recommended
+            Confidence: {{percent .Confidence}} - Manual review recommended
         </div>
         {{end}}
     </div>


### PR DESCRIPTION
`BrokerResponse.Confidence` is a 0–1 score. `partials/response-list.html` rendered it as `{{.Confidence}}%` → "0.85%". Adds a `percent` FuncMap helper (`×100`, whole number) and uses it — same formatting `eraser monitor` already does (`r.Confidence*100`).

Spotted during the Phase 2 template de-duplication.