### PR TITLE
site: expand the GDPR request and escalation guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ dist/
 /site/content/brokers/*.md
 !/site/content/brokers/_index.md
 /site/static/brokers.json
+/site/data/
 
 # Logs
 *.log

--- a/site/content/guides/sending-a-gdpr-article-17-request.md
+++ b/site/content/guides/sending-a-gdpr-article-17-request.md
@@ -1,24 +1,41 @@
 ---
 title: "Sending a GDPR Article 17 request"
-description: "What to write, who to send it to, and what a data broker must do."
+description: "What to write, who to send it to, how brokers must respond, and the exemptions they can lawfully invoke."
 ---
 
 If you live in the EU or EEA, **Article 17 of the GDPR** gives you the right to
 have a company erase the personal data it holds about you. Data brokers are
-"controllers" under the GDPR and this right applies to them squarely.
+"controllers" under the GDPR and this right applies to them squarely — it does
+not matter that you never signed up with them or that the company is based
+outside the EU, as long as it processes data about people in the EU.
+
+## What counts as "your personal data"
+
+Anything that identifies you or can be linked back to you: your name, addresses
+(current and former), phone numbers, email addresses, date of birth, relatives
+and associates, employment and property records, and any profile or score a
+broker has built from them. You are entitled to have **all** of it erased, not
+just the fields shown on a preview page.
 
 ## What to send
 
 A short email is enough. It needs to:
 
 1. **Identify you** — full name, email, and (so they can find the record)
-   postal address, and any former names, emails or addresses a broker might have
-   indexed you under.
+   postal address, plus any former names, emails or addresses a broker might
+   have indexed you under.
 2. **State the request** — that you are exercising your right to erasure under
-   Article 17 and want all personal data about you deleted.
-3. **Ask for confirmation in writing.**
+   **Article 17 of the GDPR** and want all personal data concerning you deleted.
+3. **Ask for written confirmation** once it is done.
+4. Optionally, cite **Article 19** — the broker must also tell every party it
+   sold or shared your data with to erase it, and must name those recipients if
+   you ask.
 
-Eraser's `gdpr` template does all of this. To send it yourself, run
+You do not have to give a reason. "The data is no longer necessary for the
+purpose it was collected" and "I object to the processing" (Article 17(1)(a) and
+(c)) both apply to a broker by default.
+
+Eraser's `gdpr` template covers all of this. To send it yourself, run
 `eraser draft <broker-id>` (or open the **Email** page in the web UI) and paste
 the result into your mail client.
 
@@ -26,15 +43,63 @@ the result into your mail client.
 
 The broker's privacy or data-protection address. The [broker directory](/brokers/)
 lists the address Eraser has on file for each one; where a broker only takes
-requests through a web form, that's linked instead.
+requests through a web form or a dedicated portal, that link is shown instead.
+Using their form is fine — the legal deadline is the same.
+
+## Identity verification
+
+A broker may ask you to confirm your identity before acting (Article 12(6)), but
+the request has to be **proportionate**. Confirming the email address they
+already hold, or matching a few data points from your file, is reasonable. A
+full copy of your passport usually is not — if you send ID at all, redact the
+photo, document number and any fields not needed to match your record. The
+one-month clock is paused only for the time it genuinely takes you to answer a
+proportionate verification request.
 
 ## What happens next
 
-- The controller has **one month** to respond (extendable to three for genuinely
-  complex requests — rare for a deletion).
-- They may ask you to verify your identity first. That's allowed, but it has to
-  be proportionate — a copy of your passport usually isn't.
-- If they refuse, they must tell you why and point you to your right to complain.
+- The controller has **one month** from receipt to respond. It can extend this
+  by **up to two further months** for genuinely complex or numerous requests,
+  but only if it tells you about the extension *and the reason* within the first
+  month. A plain deletion is rarely complex enough to justify this.
+- A response means a substantive answer — "done", or a reasoned refusal — not an
+  automated acknowledgement.
+- If they refuse, wholly or partly, they must tell you **why**, which exemption
+  they rely on, and that you can complain to a supervisory authority and go to
+  court.
+- They may not charge a fee unless the request is "manifestly unfounded or
+  excessive" — a single, ordinary erasure request is neither.
+
+## Exemptions a broker can lawfully invoke
+
+Article 17(3) lets a controller keep *specific* data despite your request, where
+it is still necessary for:
+
+- exercising the right to freedom of expression and information;
+- complying with a legal obligation, or a task carried out in the public
+  interest;
+- archiving in the public interest, scientific or historical research, or
+  statistics;
+- the establishment, exercise or defence of legal claims.
+
+For a data broker these almost never cover the marketing or people-search
+profile itself. If one is claimed, ask them to identify exactly which data it
+applies to and to erase the rest.
+
+## "We don't hold any data on you"
+
+Some brokers — especially adtech firms — key their records off cookies or device
+identifiers rather than your name, and may reply that they cannot find you. Ask
+them to confirm in writing that no data linked to your name, email or postal
+address is held, and to erase anything that later matches. That written "no
+data" answer is itself useful evidence.
+
+## Related rights
+
+- **Article 15 (access)** — ask what data they hold and who they shared it with,
+  before or alongside an erasure request.
+- **Article 21 (objection)** — for direct-marketing processing you can object
+  outright, and the controller must stop; there is no exemption.
 
 ## If they ignore you
 

--- a/site/content/guides/when-a-broker-ignores-you.md
+++ b/site/content/guides/when-a-broker-ignores-you.md
@@ -1,6 +1,6 @@
 ---
 title: "When a broker ignores you"
-description: "Deadlines, evidence, and how to complain to a supervisory authority."
+description: "Deadlines, the evidence to keep, and how to complain to a supervisory authority — with what to expect."
 ---
 
 Most brokers comply once a request lands — the request itself, and the liability
@@ -8,35 +8,100 @@ it creates, is what does the work. Some don't. Here's the escalation path.
 
 ## 1. Know the deadline
 
-- **GDPR (EU/EEA):** one month from the request.
-- **CCPA (California):** 45 days.
-- **Other US state laws:** typically 30–45 days.
+- **GDPR (EU/EEA):** one month from the day the controller received the request.
+  Extendable by up to two more months only if they told you so, with reasons,
+  inside the first month.
+- **UK GDPR:** the same — one month, extendable by two.
+- **CCPA (California):** 45 days, extendable once to a total of 90 with notice.
+- **Other US state laws:** typically 45 days (some 30), often with one extension.
+
+An automated "we got your email" is not a response. The deadline is missed when
+the period passes with no substantive answer — no confirmation of erasure and no
+reasoned refusal.
 
 ## 2. Keep the evidence
 
 Run `eraser export`. It produces a single document — per broker: what was sent
-and when, a copy of the request, every reply and its date, and an explicit list
-of the controllers that are **past the deadline with no substantive response**.
-`--format html` prints cleanly to PDF for attaching to a complaint.
+and when, a copy of the request, every reply and its date, the current pipeline
+stage, and an explicit list of the controllers that are **past the deadline with
+no substantive response**. `--format html` prints cleanly to PDF for attaching
+to a complaint.
 
-## 3. Complain to a supervisory authority
+A complaint is stronger if you can show:
+
+- the original request (date, recipient, full text);
+- proof it was delivered (a non-bounce, or a reply quoting it);
+- any acknowledgement or partial reply, with dates;
+- the date the deadline passed;
+- for a refusal: their stated reason, so you can say why it doesn't hold.
+
+`eraser export` assembles all of this except the raw delivery receipt from your
+mail provider — keep that too.
+
+## 3. Pick the right supervisory authority
 
 Under **GDPR Article 77** you can lodge a complaint with the data protection
-authority of the EU/EEA country where you live, where you work, or where the
-infringement happened. The [authorities page](/authorities/) lists all of them;
-`eraser export` also names the one for your country.
+authority of the EU/EEA country where you **live**, where you **work**, or where
+the **infringement happened** — your choice. The [authorities page](/authorities/)
+lists all of them; `eraser export` also names the one for your country.
 
-Set expectations: most authorities are slow — cases can take years. But an open
-complaint is itself pressure on the company.
+- **Cross-border brokers:** you still file with your *local* authority. For a
+  company operating in several EU countries, that authority coordinates with the
+  broker's "lead" authority under the one-stop-shop mechanism — you do not have
+  to work out which that is or file abroad.
+- **Germany:** for a complaint against a private company, go to the supervisory
+  authority of your own federal state (Land), not the federal BfDI. The BfDI
+  site links the list of the 16 state authorities.
+- **UK:** complain to the ICO at
+  [ico.org.uk/make-a-complaint](https://ico.org.uk/make-a-complaint/).
 
-[noyb.eu](https://noyb.eu) publishes complaint templates and sometimes takes
-strategic cases directly.
+## 4. File the complaint
 
-## 4. Consider the DELETE Act (California)
+Every authority takes complaints for free, most through an online form. Include:
 
-California's DELETE Act will let residents delete themselves from every
-registered data broker through a single request via the CPPA — check whether
-that mechanism is live before doing it broker by broker.
+- your identification and contact details;
+- the broker's name and (if known) address;
+- what you asked for and when, and that you relied on Article 17;
+- what they did or didn't do, with dates;
+- the `eraser export` PDF and your mail records as attachments;
+- what you want: an order that they erase your data and confirm it.
+
+You do not need a lawyer, and you do not need to have suffered a specific harm.
+
+## 5. What to expect
+
+- The authority must inform you of progress within **three months**, and you can
+  challenge it in court (Article 78) if it goes silent or dismisses the case
+  without good reason.
+- Outcomes range from a letter to the broker (often enough on its own), to a
+  binding order to erase, to a fine.
+- Most authorities are slow — cases can take one to several years. But an open
+  complaint is itself pressure on the company, and many brokers settle the
+  individual request as soon as the authority makes contact.
+
+## 6. Compensation
+
+**GDPR Article 82** gives a right to compensation for material *or* non-material
+damage (including distress) caused by an infringement. Claims go through the
+ordinary civil courts of your country, often via a small-claims track. Amounts
+awarded for a single ignored erasure request are modest, but the option exists.
+
+## 7. noyb and collective routes
+
+[noyb.eu](https://noyb.eu) publishes ready-to-use complaint templates, and
+sometimes takes strategic cases directly. Some countries also allow consumer or
+privacy organisations to bring representative actions under Article 80.
+
+## 8. United States
+
+- **California:** report an unresponsive business to the California Privacy
+  Protection Agency (CPPA) or the state Attorney General.
+- **Other states:** complaints go to the state Attorney General's office; there
+  is generally no private right of action for a deletion failure.
+- **California DELETE Act:** the CPPA's single-request deletion platform
+  ("DROP") was scheduled to open to consumers in 2026, with registered data
+  brokers required to honour requests from August 2026 — check the CPPA site for
+  the current status before working through brokers one by one.
 
 ---
 


### PR DESCRIPTION
The two hand-written explainer guides on the docs site were stubs (~40 lines each). This turns them into a proper reference.

**`sending-a-gdpr-article-17-request`**
- what "your personal data" covers
- Article 19 (tell downstream recipients) and how to ask for their names
- proportionate identity verification / redacting ID
- the one-month clock and the two-month extension conditions
- the Article 17(3) exemptions a broker can lawfully invoke, and why they rarely apply to a marketing/people-search profile
- the "we key off cookies, we can't find you" adtech reply
- neighbouring Article 15 (access) and Article 21 (objection) rights

**`when-a-broker-ignores-you`**
- how the deadline is actually counted; what does/doesn't count as a response
- an evidence checklist to pair with `eraser export`
- picking the supervisory authority: local filing vs one-stop-shop, Germany's Länder, UK ICO
- what to put in the complaint (it's free, no lawyer needed)
- realistic timelines and the range of outcomes
- Article 82 compensation and Article 80 representative actions
- US state routes (CPPA / state AG) and the California DELETE Act / DROP status

Also gitignores `/site/data/`, which `pages.yml` populates from `data/authorities.yaml` at build time.

Verified with `hugo v0.165.0` locally — site builds, both pages render.