### PR TITLE
brokers: structural validation + weekly liveness audit

### DIFF
--- a/.github/workflows/broker-audit.yml
+++ b/.github/workflows/broker-audit.yml
@@ -1,0 +1,34 @@
+name: Broker audit
+
+# Weekly liveness check of the broker list: every entry's email domain
+# (MX/host lookup) and website (HTTP HEAD). A failing run means one or more
+# brokers look defunct - open the run log, then investigate and prune by hand
+# (the audit never edits data/brokers.yaml). Also runnable on demand.
+
+on:
+  schedule:
+    - cron: "17 6 * * 1" # Mondays 06:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: broker-audit
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Validate structure
+        run: go run ./cmd/eraser validate-brokers
+
+      - name: Audit liveness
+        run: go run ./cmd/eraser audit-brokers --timeout 20 --fail-on-dead

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ On Windows, build it as `eraser.exe` instead (`go build -o eraser.exe ./cmd/eras
 | `eraser mark-bounced <broker-id>...` | Correct the record for brokers whose email actually bounced |
 | `eraser cleanup-bounces` | Find and clear bounced broker email addresses (keeps the broker entry) |
 | `eraser audit-brokers` | Check broker websites/email domains for signs of life |
+| `eraser validate-brokers` | Structural check of a broker list (ids, names, regions, emails, URLs) |
 | `eraser update-brokers` | Fetch the latest broker list (the list ships inside the binary; this refreshes it) |
 | `eraser monitor` | Monitor your inbox (IMAP) for broker responses |
 | `eraser pipeline` | Show pipeline status — which brokers need manual follow-up |

--- a/cmd/eraser/cmd_audit.go
+++ b/cmd/eraser/cmd_audit.go
@@ -54,6 +54,7 @@ func newAuditChecker(timeout time.Duration) *auditChecker {
 func auditBrokersCmd() *cobra.Command {
 	var region, category string
 	var timeoutSec int
+	var failOnDead bool
 
 	cmd := &cobra.Command{
 		Use:   "audit-brokers",
@@ -76,13 +77,14 @@ Examples:
   eraser audit-brokers --region eu
   eraser audit-brokers --category people-search --timeout 15`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runAuditBrokers(region, category, time.Duration(timeoutSec)*time.Second)
+			return runAuditBrokers(region, category, time.Duration(timeoutSec)*time.Second, failOnDead)
 		},
 	}
 
 	cmd.Flags().StringVar(&region, "region", "", "Only audit brokers in this region")
 	cmd.Flags().StringVar(&category, "category", "", "Only audit brokers in this category")
 	cmd.Flags().IntVar(&timeoutSec, "timeout", 10, "Per-check timeout in seconds")
+	cmd.Flags().BoolVar(&failOnDead, "fail-on-dead", false, "Exit non-zero if any broker has a dead email domain or unreachable website (for scheduled CI)")
 
 	return cmd
 }
@@ -92,7 +94,7 @@ type auditResult struct {
 	verdict auditVerdict
 }
 
-func runAuditBrokers(region, category string, timeout time.Duration) error {
+func runAuditBrokers(region, category string, timeout time.Duration, failOnDead bool) error {
 	brokerDB, err := broker.Load(brokerFile)
 	if err != nil {
 		return fmt.Errorf("failed to load brokers: %w", err)
@@ -117,6 +119,18 @@ func runAuditBrokers(region, category string, timeout time.Duration) error {
 
 	results := auditConcurrently(targets, newAuditChecker(timeout), 20)
 	printAuditResults(results)
+
+	if failOnDead {
+		dead := 0
+		for _, r := range results {
+			if r.verdict == verdictEmailDead || r.verdict == verdictWebsiteDead {
+				dead++
+			}
+		}
+		if dead > 0 {
+			return fmt.Errorf("%d broker(s) have a dead email domain or unreachable website - see the list above", dead)
+		}
+	}
 
 	return nil
 }

--- a/cmd/eraser/cmd_update_brokers.go
+++ b/cmd/eraser/cmd_update_brokers.go
@@ -15,10 +15,6 @@ import (
 
 const defaultBrokersURL = "https://raw.githubusercontent.com/drumandbytes/eraser/main/data/brokers.yaml"
 
-// minSaneBrokerCount guards against replacing the local list with a truncated
-// or empty download (a proxy error page, a bad commit, ...).
-const minSaneBrokerCount = 200
-
 func updateBrokersCmd() *cobra.Command {
 	var (
 		url   string
@@ -97,12 +93,12 @@ func runUpdateBrokers(url string, check bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to read response: %w", err)
 	}
+	if err := broker.Validate(body); err != nil {
+		return fmt.Errorf("refusing to replace the local copy - %w", err)
+	}
 	db, err := broker.Parse(body)
 	if err != nil {
 		return fmt.Errorf("downloaded file is not valid broker YAML: %w", err)
-	}
-	if len(db.Brokers) < minSaneBrokerCount {
-		return fmt.Errorf("downloaded list has only %d entries (expected at least %d) - refusing to replace the local copy", len(db.Brokers), minSaneBrokerCount)
 	}
 
 	before := currentBrokerCount()

--- a/cmd/eraser/cmd_update_brokers_test.go
+++ b/cmd/eraser/cmd_update_brokers_test.go
@@ -6,17 +6,17 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/drumandbytes/eraser/internal/broker"
 )
 
 func TestRunUpdateBrokers(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	const body = `brokers:
-` + // 3 lines per broker, need >= minSaneBrokerCount entries to pass the guard
-		""
-	yaml := body
-	for i := 0; i < minSaneBrokerCount+5; i++ {
+	// need >= broker.MinSaneBrokerCount entries to pass the guard
+	yaml := "brokers:\n"
+	for i := 0; i < broker.MinSaneBrokerCount+5; i++ {
 		yaml += "  - {id: b" + itoa(i) + ", name: B" + itoa(i) + ", email: b@x.y, region: us}\n"
 	}
 

--- a/cmd/eraser/cmd_validate_brokers.go
+++ b/cmd/eraser/cmd_validate_brokers.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/drumandbytes/eraser/data"
+	"github.com/drumandbytes/eraser/internal/broker"
+	"github.com/spf13/cobra"
+)
+
+func validateBrokersCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "validate-brokers [file]",
+		Short: "Check a brokers.yaml for structural problems",
+		Long: `Parse a broker list and report structural problems: a truncated
+entry count, missing id or name, duplicate ids, unknown region values,
+implausible email addresses, and malformed opt-out/website URLs.
+
+With no argument it checks the list this binary would load (--brokers,
+then ~/.eraser/brokers.yaml, then the embedded copy). Pass a path to check
+a candidate file before committing it. Exits non-zero if anything is wrong,
+so it doubles as a CI check.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := brokerFile
+			if len(args) == 1 {
+				path = args[0]
+			}
+
+			var raw []byte
+			var err error
+			if path != "" {
+				raw, err = os.ReadFile(path)
+				if err != nil {
+					return fmt.Errorf("failed to read %s: %w", path, err)
+				}
+			} else {
+				raw = data.BrokersYAML
+			}
+
+			if err := broker.Validate(raw); err != nil {
+				return err
+			}
+
+			db, _ := broker.Parse(raw)
+			where := path
+			if where == "" {
+				where = "embedded broker list"
+			}
+			fmt.Printf("✓ %s is valid (%d brokers)\n", where, len(db.Brokers))
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/eraser/main.go
+++ b/cmd/eraser/main.go
@@ -89,6 +89,7 @@ send via Gmail SMTP.`,
 	rootCmd.AddCommand(draftCmd())
 	rootCmd.AddCommand(markSentCmd())
 	rootCmd.AddCommand(updateBrokersCmd())
+	rootCmd.AddCommand(validateBrokersCmd())
 	rootCmd.AddCommand(guidesCmd())
 
 	if err := rootCmd.Execute(); err != nil {

--- a/docs/auditing.md
+++ b/docs/auditing.md
@@ -67,6 +67,20 @@ public. So EU expansion is per-country research. The sources worth mining:
   preference programme; participating companies have a defined opt-out.
 - **noyb** and **GDPRhub** case pages - name specific controllers.
 
+## Keeping `data/brokers.yaml` honest
+
+Two checks, both also wired into CI:
+
+- **Structure** - `eraser validate-brokers` (or `go test ./internal/broker/...`,
+  which runs `Validate` against the embedded copy on every PR): a sane entry
+  count, required `id`/`name`, unique ids, known `region` values, plausible
+  emails, well-formed URLs. Run `eraser validate-brokers candidates.yaml` before
+  merging a batch from the importer.
+- **Liveness** - `.github/workflows/broker-audit.yml` runs `eraser audit-brokers
+  --fail-on-dead` every Monday. A red run means one or more brokers look
+  defunct; open the log, investigate, and prune by hand (the audit never edits
+  the file). Also runnable from the Actions tab on demand.
+
 ## Security/Correctness Sweep (2026-08)
 
 A focused review of `internal/browser`, `internal/web`, `internal/history`, and `internal/inbox` (the packages that had zero test coverage and handle either real user PII, untrusted email content, or concurrent web-server state) turned up and fixed 15 findings - see the corresponding commits for detail:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -20,7 +20,8 @@ go test ./...
 ./eraser add-broker
 ./eraser mark-bounced <broker-id>...   # correct the record when an email actually bounced
 ./eraser cleanup-bounces               # find + clear bounced broker emails
-./eraser audit-brokers [--region eu] [--category financial-b2b] [--timeout 15]  # MX/website liveness check
+./eraser audit-brokers [--region eu] [--category financial-b2b] [--timeout 15] [--fail-on-dead]  # MX/website liveness check
+./eraser validate-brokers [file]      # structural check: ids, names, regions, emails, URLs (exit non-zero on any problem)
 ./eraser update-brokers [--check]      # fetch the latest broker list (conditional; writes ~/.eraser/brokers.yaml)
 ./eraser guides [-o site/content] [--format md|html]  # generate opt-out guide pages + a JSON broker directory
 ./eraser monitor                       # IMAP inbox monitoring for broker replies

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -5,12 +5,28 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/drumandbytes/eraser/data"
 	"gopkg.in/yaml.v3"
 )
+
+// MinSaneBrokerCount is the floor below which a broker database is assumed to
+// be truncated or corrupt rather than legitimately small. Used both by
+// `update-brokers` (before replacing the local copy) and by Validate.
+const MinSaneBrokerCount = 200
+
+// knownRegions is the closed set of region values the rest of the code
+// branches on (see Filter). A typo like "usa" would silently drop a broker
+// from every region-filtered send.
+var knownRegions = map[string]bool{"us": true, "eu": true, "global": true}
+
+// looseEmailRe is a deliberately permissive check - it only catches obvious
+// breakage (missing @, no dot in the domain, whitespace), not RFC compliance.
+var looseEmailRe = regexp.MustCompile(`^[^\s@]+@[^\s@]+\.[^\s@]+$`)
 
 func isValidURL(rawURL string) bool {
 	if rawURL == "" {
@@ -59,6 +75,62 @@ func Parse(raw []byte) (*BrokerDatabase, error) {
 		sanitizeBroker(&db.Brokers[i])
 	}
 	return &db, nil
+}
+
+// Validate checks structural invariants of a raw broker YAML document: a sane
+// entry count, required id/name, unique ids, known region values, plausible
+// emails, and well-formed http(s) URLs. It parses the bytes itself (without
+// the sanitizing Parse applies) so a malformed URL is reported rather than
+// silently blanked. Returns a single error listing every problem found, or
+// nil. This is what CI runs against data/brokers.yaml.
+func Validate(raw []byte) error {
+	var db BrokerDatabase
+	if err := yaml.Unmarshal(raw, &db); err != nil {
+		return fmt.Errorf("failed to parse broker data: %w", err)
+	}
+
+	var problems []string
+	if len(db.Brokers) < MinSaneBrokerCount {
+		problems = append(problems, fmt.Sprintf("only %d brokers (expected at least %d) - looks truncated", len(db.Brokers), MinSaneBrokerCount))
+	}
+
+	seen := make(map[string]int, len(db.Brokers))
+	for i, b := range db.Brokers {
+		id := strings.TrimSpace(b.ID)
+		label := fmt.Sprintf("entry %d", i)
+		if id != "" {
+			label = fmt.Sprintf("entry %d (%s)", i, id)
+		}
+
+		if id == "" {
+			problems = append(problems, label+": missing id")
+		} else if prev, dup := seen[strings.ToLower(id)]; dup {
+			problems = append(problems, fmt.Sprintf("%s: duplicate id, also at entry %d", label, prev))
+		} else {
+			seen[strings.ToLower(id)] = i
+		}
+
+		if strings.TrimSpace(b.Name) == "" {
+			problems = append(problems, label+": missing name")
+		}
+		if b.Region != "" && !knownRegions[strings.ToLower(strings.TrimSpace(b.Region))] {
+			problems = append(problems, label+": unknown region "+strconv.Quote(b.Region))
+		}
+		if b.Email != "" && !looseEmailRe.MatchString(strings.TrimSpace(b.Email)) {
+			problems = append(problems, label+": implausible email "+strconv.Quote(b.Email))
+		}
+		if b.OptOutURL != "" && !isValidURL(b.OptOutURL) {
+			problems = append(problems, label+": opt_out_url is not a valid http(s) URL: "+strconv.Quote(b.OptOutURL))
+		}
+		if b.Website != "" && !isValidURL(b.Website) {
+			problems = append(problems, label+": website is not a valid http(s) URL: "+strconv.Quote(b.Website))
+		}
+	}
+
+	if len(problems) > 0 {
+		return fmt.Errorf("broker database has %d problem(s):\n  - %s", len(problems), strings.Join(problems, "\n  - "))
+	}
+	return nil
 }
 
 // LoadFromFile parses a broker YAML file from an explicit path.

--- a/internal/broker/validate_test.go
+++ b/internal/broker/validate_test.go
@@ -1,0 +1,63 @@
+package broker
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/drumandbytes/eraser/data"
+)
+
+// TestEmbeddedBrokerDataValid is the CI guard: the broker list shipped in the
+// binary must always pass structural validation.
+func TestEmbeddedBrokerDataValid(t *testing.T) {
+	if err := Validate(data.BrokersYAML); err != nil {
+		t.Fatalf("embedded data/brokers.yaml is invalid:\n%v", err)
+	}
+}
+
+func TestValidateCatchesProblems(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{"truncated", "brokers:\n  - id: a\n    name: A\n    region: us\n", "truncated"},
+		{"duplicate id", fillerYAML("  - id: filler-0\n    name: Dup\n    region: us\n"), "duplicate id"},
+		{"missing name", fillerYAML("  - id: lonely\n    region: us\n"), "missing name"},
+		{"missing id", fillerYAML("  - name: No ID\n    region: us\n"), "missing id"},
+		{"unknown region", fillerYAML("  - id: weird\n    name: Weird\n    region: usa\n"), "unknown region"},
+		{"implausible email", fillerYAML("  - id: bade\n    name: Bad Email\n    region: us\n    email: not-an-email\n"), "implausible email"},
+		{"malformed opt_out_url", fillerYAML("  - id: badurl\n    name: Bad URL\n    region: us\n    opt_out_url: \"javascript:alert(1)\"\n"), "opt_out_url"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate([]byte(tc.yaml))
+			if err == nil {
+				t.Fatalf("expected an error mentioning %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not mention %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateAcceptsGoodData(t *testing.T) {
+	if err := Validate([]byte(fillerYAML(""))); err != nil {
+		t.Fatalf("expected valid, got: %v", err)
+	}
+}
+
+// fillerYAML returns a brokers document with MinSaneBrokerCount valid entries
+// plus whatever extra entry lines the caller appends.
+func fillerYAML(extra string) string {
+	var b strings.Builder
+	b.WriteString("brokers:\n")
+	for i := 0; i < MinSaneBrokerCount; i++ {
+		fmt.Fprintf(&b, "  - id: filler-%d\n    name: Filler %d\n    region: us\n    email: privacy@filler%d.example\n", i, i, i)
+	}
+	b.WriteString(extra)
+	return b.String()
+}


### PR DESCRIPTION
`data/brokers.yaml` is the hand-maintained asset that makes this fork worth running, so this adds guardrails around it.

**Structural validation** — `broker.Validate(raw []byte)`:
- entry-count floor (`broker.MinSaneBrokerCount`, now a shared const — `update-brokers` used to have its own private copy and now runs the full `Validate` on a download before accepting it)
- required `id` / `name`, unique ids (case-insensitive), known `region` values (`us`/`eu`/`global`), plausible email addresses, well-formed `http(s)` opt-out / website URLs
- `TestEmbeddedBrokerDataValid` runs it against the embedded copy, so the **existing CI `go test`** now fails on a bad hand-edit — no new required workflow
- `eraser validate-brokers [file]` to check a candidate file locally before merging an importer batch

**Liveness** — `.github/workflows/broker-audit.yml`:
- Monday cron + manual dispatch
- runs `validate-brokers`, then `audit-brokers --fail-on-dead` (new flag: non-zero exit when an email domain or website looks dead)
- a red run is the signal to investigate and prune by hand; the audit never edits the file

Docs: `commands.md`, README command table, `auditing.md` ("Keeping `data/brokers.yaml` honest").

`go build` / `vet` / `gofmt` / `go test ./...` / `golangci-lint` all clean; `validate-brokers` passes on the current 763-entry list.