### PR TITLE
cleanup: ponytail audit + humanize-comments pass

### DIFF
--- a/cmd/eraser/cmd_bounces.go
+++ b/cmd/eraser/cmd_bounces.go
@@ -50,18 +50,15 @@ Examples:
 }
 
 func runCleanupBounces(remove bool, days int) error {
-	// Load config
 	cfg, err := config.Load(resolveConfigPath())
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	// Check if inbox is configured
 	if !cfg.Inbox.Enabled {
 		return fmt.Errorf("inbox monitoring not configured. Run 'eraser init' to set up")
 	}
 
-	// Load broker database
 	brokerPath := resolveBrokerWritePath()
 	brokerDB, err := broker.LoadFromFile(brokerPath)
 	if err != nil {
@@ -72,17 +69,14 @@ func runCleanupBounces(remove bool, days int) error {
 	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 	fmt.Println()
 
-	// Create inbox monitor
 	monitor := inbox.NewMonitor(cfg.Inbox, brokerDB.Brokers)
 
-	// Connect
 	ctx := context.Background()
 	if err := monitor.Connect(ctx); err != nil {
 		return fmt.Errorf("failed to connect to inbox: %w", err)
 	}
 	defer func() { _ = monitor.Disconnect() }()
 
-	// Fetch bounce emails
 	bounceEmails, err := monitor.FetchBounceEmails(ctx, days)
 	if err != nil {
 		return fmt.Errorf("failed to fetch bounce emails: %w", err)
@@ -105,14 +99,12 @@ func runCleanupBounces(remove bool, days int) error {
 	var bouncedBrokers []bouncedBroker
 
 	for _, email := range bounceEmails {
-		// Extract the bounced recipient
 		bouncedRecipient := inbox.ExtractBouncedRecipient(&email)
 		if bouncedRecipient == "" {
 			fmt.Printf("⚠️  Could not extract bounced address from: %s\n", email.Subject)
 			continue
 		}
 
-		// Find the broker
 		b := brokerDB.FindByEmail(bouncedRecipient)
 		if b == nil {
 			fmt.Printf("⚠️  %s - not found in broker database\n", bouncedRecipient)
@@ -157,7 +149,6 @@ func runCleanupBounces(remove bool, days int) error {
 		}
 	}
 
-	// Save with backup
 	if err := brokerDB.SaveWithBackup(brokerPath); err != nil {
 		return fmt.Errorf("failed to save broker database: %w", err)
 	}

--- a/cmd/eraser/cmd_confirm.go
+++ b/cmd/eraser/cmd_confirm.go
@@ -69,13 +69,11 @@ func runConfirm(confirmURL, brokerID string, pending, validateDomain, dryRun boo
 		return err
 	}
 
-	// Load brokers for domain validation
 	brokerDB, err := broker.Load(brokerFile)
 	if err != nil {
 		return fmt.Errorf("failed to load brokers: %w", err)
 	}
 
-	// Initialize history store
 	store, err := history.NewStore(history.DBPathFor(resolveConfigPath()))
 	if err != nil {
 		return fmt.Errorf("failed to initialize history: %w", err)
@@ -86,7 +84,6 @@ func runConfirm(confirmURL, brokerID string, pending, validateDomain, dryRun boo
 	var brokerDomains []string
 	for _, b := range brokerDB.Brokers {
 		if b.Website != "" {
-			// Extract domain from website
 			domain := strings.TrimPrefix(b.Website, "https://")
 			domain = strings.TrimPrefix(domain, "http://")
 			domain = strings.TrimSuffix(domain, "/")
@@ -95,14 +92,12 @@ func runConfirm(confirmURL, brokerID string, pending, validateDomain, dryRun boo
 			}
 			brokerDomains = append(brokerDomains, domain)
 
-			// Also add the bare domain without www prefix
 			if strings.HasPrefix(domain, "www.") {
 				brokerDomains = append(brokerDomains, strings.TrimPrefix(domain, "www."))
 			}
 		}
 	}
 
-	// Create confirmation handler
 	handler := browser.NewConfirmationHandler(brokerDomains)
 
 	fmt.Println("🔗 Confirmation Link Handler")
@@ -122,7 +117,6 @@ func runConfirm(confirmURL, brokerID string, pending, validateDomain, dryRun boo
 			URL      string
 		}{BrokerID: brokerID, URL: confirmURL})
 	} else if brokerID != "" {
-		// Get URL for specific broker from pipeline
 		responses, err := store.GetBrokerResponses(activeProfile.ID, "confirmation_required", false, 100)
 		if err != nil {
 			return fmt.Errorf("failed to get broker responses: %w", err)
@@ -144,7 +138,6 @@ func runConfirm(confirmURL, brokerID string, pending, validateDomain, dryRun boo
 			return fmt.Errorf("no confirmation URL found for broker: %s", brokerID)
 		}
 	} else if pending {
-		// Get all pending confirmation links
 		responses, err := store.GetBrokerResponses(activeProfile.ID, "confirmation_required", false, 100)
 		if err != nil {
 			return fmt.Errorf("failed to get broker responses: %w", err)
@@ -173,7 +166,6 @@ func runConfirm(confirmURL, brokerID string, pending, validateDomain, dryRun boo
 	}
 	fmt.Println()
 
-	// Process each link
 	successCount := 0
 	failCount := 0
 
@@ -184,7 +176,6 @@ func runConfirm(confirmURL, brokerID string, pending, validateDomain, dryRun boo
 		}
 		fmt.Printf("       URL: %s\n", truncateURL(link.URL, 60))
 
-		// Validate domain if requested
 		if validateDomain {
 			valid, domain, err := handler.ValidateDomain(link.URL)
 			if err != nil {
@@ -216,7 +207,6 @@ func runConfirm(confirmURL, brokerID string, pending, validateDomain, dryRun boo
 			continue
 		}
 
-		// Show result
 		fmt.Printf("       HTTP Status: %d\n", result.StatusCode)
 		if len(result.RedirectPath) > 1 {
 			fmt.Printf("       Redirects: %d hops\n", len(result.RedirectPath)-1)
@@ -225,13 +215,11 @@ func runConfirm(confirmURL, brokerID string, pending, validateDomain, dryRun boo
 			fmt.Printf("       Final URL: %s\n", truncateURL(result.FinalURL, 60))
 		}
 
-		// Extract and show status
 		status := handler.ExtractConfirmationStatus(result)
 		if result.Success {
 			fmt.Printf("       ✅ %s\n", status)
 			successCount++
 
-			// Update pipeline status
 			if link.BrokerID != "" {
 				_ = store.UpdatePipelineStatus(activeProfile.ID, link.BrokerID, history.PipelineConfirmed)
 			}

--- a/cmd/eraser/cmd_fill.go
+++ b/cmd/eraser/cmd_fill.go
@@ -69,7 +69,6 @@ Examples:
 }
 
 func runFill(brokerID, formURL string, headless, headlessFlagSet, autoSubmit bool, screenshotDir string, pending bool, waitForCaptcha bool) error {
-	// Load config for profile data
 	cfg, err := config.Load(resolveConfigPath())
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
@@ -93,7 +92,6 @@ func runFill(brokerID, formURL string, headless, headlessFlagSet, autoSubmit boo
 	var brokerDomains []string
 	for _, b := range brokerDB.Brokers {
 		if b.Website != "" {
-			// Extract domain from website
 			domain := strings.TrimPrefix(b.Website, "https://")
 			domain = strings.TrimPrefix(domain, "http://")
 			domain = strings.TrimSuffix(domain, "/")
@@ -102,7 +100,6 @@ func runFill(brokerID, formURL string, headless, headlessFlagSet, autoSubmit boo
 			}
 			brokerDomains = append(brokerDomains, domain)
 
-			// Also add the bare domain without www prefix
 			if strings.HasPrefix(domain, "www.") {
 				brokerDomains = append(brokerDomains, strings.TrimPrefix(domain, "www."))
 			}
@@ -115,20 +112,17 @@ func runFill(brokerID, formURL string, headless, headlessFlagSet, autoSubmit boo
 		headless = cfg.Pipeline.Headless()
 	}
 
-	// Set default screenshot directory
 	if screenshotDir == "" {
 		home, _ := os.UserHomeDir()
 		screenshotDir = filepath.Join(home, ".eraser", "screenshots")
 	}
 
-	// Initialize history store
 	store, err := history.NewStore(history.DBPathFor(resolveConfigPath()))
 	if err != nil {
 		return fmt.Errorf("failed to initialize history: %w", err)
 	}
 	defer func() { _ = store.Close() }()
 
-	// Create browser config
 	browserCfg := browser.DefaultConfig()
 	browserCfg.Headless = headless
 	browserCfg.ScreenshotDir = screenshotDir
@@ -136,7 +130,6 @@ func runFill(brokerID, formURL string, headless, headlessFlagSet, autoSubmit boo
 		browserCfg.Timeout = time.Duration(cfg.Pipeline.BrowserTimeoutSec) * time.Second
 	}
 
-	// Set up wait for CAPTCHA if requested
 	if waitForCaptcha {
 		if headless {
 			fmt.Println("⚠️  Warning: --wait requires --headless=false to be useful")
@@ -154,7 +147,6 @@ func runFill(brokerID, formURL string, headless, headlessFlagSet, autoSubmit boo
 		}
 	}
 
-	// Create browser instance
 	b, err := browser.New(browserCfg, &activeProfile.Profile, brokerDomains)
 	if err != nil {
 		return fmt.Errorf("failed to create browser: %w", err)
@@ -178,7 +170,6 @@ func runFill(brokerID, formURL string, headless, headlessFlagSet, autoSubmit boo
 			URL      string
 		}{BrokerID: brokerID, URL: formURL})
 	} else if brokerID != "" {
-		// Get URL for specific broker from pipeline
 		responses, err := store.GetBrokerResponses(activeProfile.ID, "form_required", false, 100)
 		if err != nil {
 			return fmt.Errorf("failed to get broker responses: %w", err)
@@ -200,7 +191,6 @@ func runFill(brokerID, formURL string, headless, headlessFlagSet, autoSubmit boo
 			return fmt.Errorf("no form URL found for broker: %s", brokerID)
 		}
 	} else if pending {
-		// Get all pending forms
 		responses, err := store.GetBrokerResponses(activeProfile.ID, "form_required", false, 100)
 		if err != nil {
 			return fmt.Errorf("failed to get broker responses: %w", err)
@@ -226,7 +216,6 @@ func runFill(brokerID, formURL string, headless, headlessFlagSet, autoSubmit boo
 	fmt.Printf("📋 Forms to process: %d\n", len(formsToFill))
 	fmt.Println()
 
-	// Process each form
 	for i, form := range formsToFill {
 		fmt.Printf("[%d/%d] Processing %s\n", i+1, len(formsToFill), form.URL)
 
@@ -240,7 +229,6 @@ func runFill(brokerID, formURL string, headless, headlessFlagSet, autoSubmit boo
 			continue
 		}
 
-		// Print result
 		if len(result.FieldsFilled) > 0 {
 			fmt.Printf("       ✅ Filled fields: %s\n", strings.Join(result.FieldsFilled, ", "))
 		}
@@ -251,7 +239,6 @@ func runFill(brokerID, formURL string, headless, headlessFlagSet, autoSubmit boo
 		if result.CaptchaFound {
 			fmt.Printf("       🤖 CAPTCHA detected: %s\n", result.CaptchaType)
 
-			// Store profile data as JSON for the helper page
 			profileData := map[string]string{
 				"email":     activeProfile.Email,
 				"firstName": activeProfile.FirstName,
@@ -265,7 +252,6 @@ func runFill(brokerID, formURL string, headless, headlessFlagSet, autoSubmit boo
 			}
 			profileJSON, _ := json.Marshal(profileData)
 
-			// Create pending task for CAPTCHA
 			task := &history.PendingTask{
 				ProfileID:    activeProfile.ID,
 				BrokerID:     form.BrokerID,
@@ -285,7 +271,6 @@ func runFill(brokerID, formURL string, headless, headlessFlagSet, autoSubmit boo
 				fmt.Printf("       📝 Created CAPTCHA task for manual solving\n")
 			}
 
-			// Update pipeline status
 			_ = store.UpdatePipelineStatus(activeProfile.ID, form.BrokerID, history.PipelineAwaitingCaptcha)
 		} else if result.SubmitAttempted {
 			fmt.Printf("       📨 Form submitted!\n")

--- a/cmd/eraser/cmd_monitor.go
+++ b/cmd/eraser/cmd_monitor.go
@@ -49,7 +49,6 @@ func runMonitor(days int, once bool, watch bool) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	// Validate inbox config
 	if err := cfg.ValidateInbox(); err != nil {
 		fmt.Println("📧 Inbox monitoring is not configured.")
 		fmt.Println()
@@ -68,27 +67,22 @@ func runMonitor(days int, once bool, watch bool) error {
 		return err
 	}
 
-	// Load brokers for domain matching
 	brokerDB, err := broker.Load(brokerFile)
 	if err != nil {
 		return fmt.Errorf("failed to load brokers: %w", err)
 	}
 
-	// Initialize history store
 	store, err := history.NewStore(history.DBPathFor(resolveConfigPath()))
 	if err != nil {
 		return fmt.Errorf("failed to initialize history: %w", err)
 	}
 	defer func() { _ = store.Close() }()
 
-	// Create inbox monitor
 	monitor := inbox.NewMonitor(cfg.Inbox, brokerDB.Brokers)
 
-	// Connect to IMAP
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Handle signals for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
@@ -105,7 +99,6 @@ func runMonitor(days int, once bool, watch bool) error {
 	fmt.Printf("📬 Monitoring inbox for broker responses (last %d days)...\n", days)
 	fmt.Println()
 
-	// Fetch emails from known broker domains
 	emails, err := monitor.FetchBrokerEmails(ctx, days)
 	if err != nil {
 		return fmt.Errorf("failed to fetch emails: %w", err)
@@ -136,7 +129,6 @@ func runMonitor(days int, once bool, watch bool) error {
 			profileID = history.DefaultProfileID
 		}
 
-		// Store in database
 		brokerResp := &history.BrokerResponse{
 			ProfileID:    profileID,
 			BrokerID:     email.BrokerID,
@@ -175,7 +167,6 @@ func runMonitor(days int, once bool, watch bool) error {
 		// Ignore error if no matching record
 		_ = store.UpdatePipelineStatus(profileID, email.BrokerID, pipelineStatus)
 
-		// Print summary
 		printClassifiedResponse(classified)
 	}
 
@@ -205,7 +196,6 @@ func runMonitor(days int, once bool, watch bool) error {
 		}
 	}
 
-	// Print summary
 	summary := inbox.SummarizeResponses(responses)
 	fmt.Println()
 	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
@@ -223,7 +213,6 @@ func runMonitor(days int, once bool, watch bool) error {
 		return nil
 	}
 
-	// Watch for new emails if requested
 	if watch {
 		fmt.Println()
 		fmt.Println("👀 Watching for new emails... (Ctrl+C to stop)")
@@ -240,7 +229,6 @@ func runMonitor(days int, once bool, watch bool) error {
 				profileID = history.DefaultProfileID
 			}
 
-			// Store response
 			brokerResp := &history.BrokerResponse{
 				ProfileID:    profileID,
 				BrokerID:     email.BrokerID,

--- a/cmd/eraser/cmd_pipeline.go
+++ b/cmd/eraser/cmd_pipeline.go
@@ -45,7 +45,6 @@ func runPipelineStatus() error {
 	}
 	fmt.Println()
 
-	// Get pipeline stats
 	pipelineStats, err := store.GetPipelineStats(activeProfile.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get pipeline stats: %w", err)
@@ -63,7 +62,6 @@ func runPipelineStatus() error {
 	fmt.Printf("  ❌ Rejected:              %d\n", pipelineStats[history.PipelineRejected])
 	fmt.Printf("  💥 Failed:                %d\n", pipelineStats[history.PipelineFailed])
 
-	// Get response stats
 	responseStats, err := store.GetResponseStats(activeProfile.ID)
 	if err != nil {
 		fmt.Printf("\n⚠️  Could not get response stats: %v\n", err)
@@ -75,7 +73,6 @@ func runPipelineStatus() error {
 		}
 	}
 
-	// Get pending tasks
 	pending, completed, skipped, err := store.GetPendingTaskStats(activeProfile.ID)
 	if err != nil {
 		fmt.Printf("\n⚠️  Could not get task stats: %v\n", err)
@@ -87,7 +84,6 @@ func runPipelineStatus() error {
 		fmt.Printf("  ⏭️  Skipped:   %d\n", skipped)
 	}
 
-	// Show actionable items
 	tasks, err := store.GetPendingTasks(activeProfile.ID, "", "pending")
 	if err == nil && len(tasks) > 0 {
 		fmt.Println()

--- a/cmd/eraser/cmd_send.go
+++ b/cmd/eraser/cmd_send.go
@@ -161,7 +161,7 @@ func runSend() error {
 	}
 
 	// Initialize email sender (unless dry-run)
-	var sender email.Sender
+	var sender *email.SMTPSender
 	if !cfg.Options.DryRun {
 		sender, err = email.NewSender(cfg.Email)
 		if err != nil {

--- a/cmd/eraser/cmd_send.go
+++ b/cmd/eraser/cmd_send.go
@@ -82,7 +82,6 @@ func runSend() error {
 		return fmt.Errorf("failed to load brokers: %w", err)
 	}
 
-	// Filter brokers
 	brokers := brokerDB.Filter(cfg.Options.Regions, cfg.Options.ExcludedBrokers, cfg.Options.ExcludedCategories)
 	if len(brokers) == 0 {
 		fmt.Println("No brokers to process.")
@@ -154,7 +153,6 @@ func runSend() error {
 		}
 	}
 
-	// Initialize template engine
 	tmplEngine, err := template.NewEngine()
 	if err != nil {
 		return fmt.Errorf("failed to initialize templates: %w", err)
@@ -169,7 +167,6 @@ func runSend() error {
 		}
 	}
 
-	// Process brokers
 	if cfg.Options.DryRun {
 		fmt.Println("🔍 DRY RUN MODE - No emails will be sent")
 		fmt.Println()
@@ -200,7 +197,6 @@ func runSend() error {
 			continue
 		}
 
-		// Render email
 		emailMsg, err := tmplEngine.Render(cfg.Options.Template, activeProfile.Profile, b)
 		if err != nil {
 			fmt.Printf("  ❌ Failed to render template: %v\n", err)
@@ -213,7 +209,6 @@ func runSend() error {
 			fmt.Printf("  📍 To: %s\n", b.Email)
 			successCount++
 		} else {
-			// Send email
 			msg := email.Message{
 				To:      b.Email,
 				From:    cfg.Email.From,

--- a/cmd/eraser/cmd_serve.go
+++ b/cmd/eraser/cmd_serve.go
@@ -59,26 +59,22 @@ func runServe(port int) error {
 		return fmt.Errorf("failed to load brokers: %w", err)
 	}
 
-	// Initialize history store
 	store, err := history.NewStore(history.DBPathFor(configPath))
 	if err != nil {
 		return fmt.Errorf("failed to initialize history: %w", err)
 	}
 	defer func() { _ = store.Close() }()
 
-	// Initialize email template engine
 	tmplEngine, err := template.NewEngine()
 	if err != nil {
 		return fmt.Errorf("failed to initialize templates: %w", err)
 	}
 
-	// Create and start web server
 	server, err := web.NewServer(port, cfg, configPath, brokerDB, store, tmplEngine)
 	if err != nil {
 		return fmt.Errorf("failed to create web server: %w", err)
 	}
 
-	// Handle graceful shutdown
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 

--- a/cmd/eraser/cmd_status.go
+++ b/cmd/eraser/cmd_status.go
@@ -42,13 +42,11 @@ func runStatus(limit int) error {
 	}
 	defer func() { _ = store.Close() }()
 
-	// Get overall stats
 	total, sent, failed, err := store.GetStats(activeProfile.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get stats: %w", err)
 	}
 
-	// Get monthly stats
 	monthlySent, monthlyFailed, err := store.GetMonthlyStats(activeProfile.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get monthly stats: %w", err)
@@ -69,7 +67,6 @@ func runStatus(limit int) error {
 	fmt.Printf("  Sent: %d\n", monthlySent)
 	fmt.Printf("  Failed: %d\n", monthlyFailed)
 
-	// Get recent requests
 	records, err := store.GetRecentRequests(activeProfile.ID, limit)
 	if err != nil {
 		return fmt.Errorf("failed to get recent requests: %w", err)

--- a/cmd/eraser/cmd_update_brokers.go
+++ b/cmd/eraser/cmd_update_brokers.go
@@ -93,12 +93,9 @@ func runUpdateBrokers(url string, check bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to read response: %w", err)
 	}
-	if err := broker.Validate(body); err != nil {
-		return fmt.Errorf("refusing to replace the local copy - %w", err)
-	}
-	db, err := broker.Parse(body)
+	db, err := broker.Validate(body)
 	if err != nil {
-		return fmt.Errorf("downloaded file is not valid broker YAML: %w", err)
+		return fmt.Errorf("refusing to replace the local copy - %w", err)
 	}
 
 	before := currentBrokerCount()

--- a/cmd/eraser/cmd_validate_brokers.go
+++ b/cmd/eraser/cmd_validate_brokers.go
@@ -39,11 +39,11 @@ so it doubles as a CI check.`,
 				raw = data.BrokersYAML
 			}
 
-			if err := broker.Validate(raw); err != nil {
+			db, err := broker.Validate(raw)
+			if err != nil {
 				return err
 			}
 
-			db, _ := broker.Parse(raw)
 			where := path
 			if where == "" {
 				where = "embedded broker list"

--- a/cmd/eraser/main.go
+++ b/cmd/eraser/main.go
@@ -70,7 +70,6 @@ send via Gmail SMTP.`,
 	rootCmd.PersistentFlags().StringVar(&brokerFile, "brokers", "", "broker database file (default is ./data/brokers.yaml)")
 	rootCmd.PersistentFlags().StringVar(&profileFlag, "profile", "", "Profile ID to operate as (default: the only configured profile; required if you've configured more than one via 'eraser profile add')")
 
-	// Add commands
 	rootCmd.AddCommand(initCmd())
 	rootCmd.AddCommand(sendCmd())
 	rootCmd.AddCommand(serveCmd())

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -295,7 +295,6 @@ func (db *BrokerDatabase) RemoveByID(id string) *Broker {
 
 // SaveWithBackup saves the database to file, creating a backup first
 func (db *BrokerDatabase) SaveWithBackup(path string) error {
-	// Create backup
 	if _, err := os.Stat(path); err == nil {
 		data, err := os.ReadFile(path)
 		if err != nil {

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -77,16 +76,16 @@ func Parse(raw []byte) (*BrokerDatabase, error) {
 	return &db, nil
 }
 
-// Validate checks structural invariants of a raw broker YAML document: a sane
-// entry count, required id/name, unique ids, known region values, plausible
-// emails, and well-formed http(s) URLs. It parses the bytes itself (without
-// the sanitizing Parse applies) so a malformed URL is reported rather than
-// silently blanked. Returns a single error listing every problem found, or
-// nil. This is what CI runs against data/brokers.yaml.
-func Validate(raw []byte) error {
+// Validate parses raw broker YAML and checks structural invariants: sane entry
+// count, required id/name, unique ids, known regions, plausible emails,
+// well-formed http(s) URLs. Unlike Parse it doesn't sanitize, so a malformed
+// URL is reported rather than silently blanked. One error lists every problem
+// (CI runs this against data/brokers.yaml); the parsed db is returned so
+// callers skip a second unmarshal.
+func Validate(raw []byte) (*BrokerDatabase, error) {
 	var db BrokerDatabase
 	if err := yaml.Unmarshal(raw, &db); err != nil {
-		return fmt.Errorf("failed to parse broker data: %w", err)
+		return nil, fmt.Errorf("failed to parse broker data: %w", err)
 	}
 
 	var problems []string
@@ -99,7 +98,7 @@ func Validate(raw []byte) error {
 		id := strings.TrimSpace(b.ID)
 		label := fmt.Sprintf("entry %d", i)
 		if id != "" {
-			label = fmt.Sprintf("entry %d (%s)", i, id)
+			label += " (" + id + ")"
 		}
 
 		if id == "" {
@@ -114,23 +113,23 @@ func Validate(raw []byte) error {
 			problems = append(problems, label+": missing name")
 		}
 		if b.Region != "" && !knownRegions[strings.ToLower(strings.TrimSpace(b.Region))] {
-			problems = append(problems, label+": unknown region "+strconv.Quote(b.Region))
+			problems = append(problems, fmt.Sprintf("%s: unknown region %q", label, b.Region))
 		}
 		if b.Email != "" && !looseEmailRe.MatchString(strings.TrimSpace(b.Email)) {
-			problems = append(problems, label+": implausible email "+strconv.Quote(b.Email))
+			problems = append(problems, fmt.Sprintf("%s: implausible email %q", label, b.Email))
 		}
 		if b.OptOutURL != "" && !isValidURL(b.OptOutURL) {
-			problems = append(problems, label+": opt_out_url is not a valid http(s) URL: "+strconv.Quote(b.OptOutURL))
+			problems = append(problems, fmt.Sprintf("%s: opt_out_url is not a valid http(s) URL: %q", label, b.OptOutURL))
 		}
 		if b.Website != "" && !isValidURL(b.Website) {
-			problems = append(problems, label+": website is not a valid http(s) URL: "+strconv.Quote(b.Website))
+			problems = append(problems, fmt.Sprintf("%s: website is not a valid http(s) URL: %q", label, b.Website))
 		}
 	}
 
 	if len(problems) > 0 {
-		return fmt.Errorf("broker database has %d problem(s):\n  - %s", len(problems), strings.Join(problems, "\n  - "))
+		return &db, fmt.Errorf("broker database has %d problem(s):\n  - %s", len(problems), strings.Join(problems, "\n  - "))
 	}
-	return nil
+	return &db, nil
 }
 
 // LoadFromFile parses a broker YAML file from an explicit path.

--- a/internal/broker/validate_test.go
+++ b/internal/broker/validate_test.go
@@ -11,7 +11,7 @@ import (
 // TestEmbeddedBrokerDataValid is the CI guard: the broker list shipped in the
 // binary must always pass structural validation.
 func TestEmbeddedBrokerDataValid(t *testing.T) {
-	if err := Validate(data.BrokersYAML); err != nil {
+	if _, err := Validate(data.BrokersYAML); err != nil {
 		t.Fatalf("embedded data/brokers.yaml is invalid:\n%v", err)
 	}
 }
@@ -33,7 +33,7 @@ func TestValidateCatchesProblems(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := Validate([]byte(tc.yaml))
+			_, err := Validate([]byte(tc.yaml))
 			if err == nil {
 				t.Fatalf("expected an error mentioning %q, got nil", tc.want)
 			}
@@ -45,7 +45,7 @@ func TestValidateCatchesProblems(t *testing.T) {
 }
 
 func TestValidateAcceptsGoodData(t *testing.T) {
-	if err := Validate([]byte(fillerYAML(""))); err != nil {
+	if _, err := Validate([]byte(fillerYAML(""))); err != nil {
 		t.Fatalf("expected valid, got: %v", err)
 	}
 }

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -81,10 +81,8 @@ func New(cfg BrowserConfig, profile *config.Profile, allowedDomains []string) (*
 		opts = append(opts, chromedp.Headless)
 	}
 
-	// Create allocator context
 	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), opts...)
 
-	// Create browser context
 	ctx, cancel := chromedp.NewContext(allocCtx)
 
 	return &Browser{
@@ -133,7 +131,6 @@ func (b *Browser) NavigateAndFill(url string, brokerID string, autoSubmit bool) 
 		}
 	}
 
-	// Create a context with timeout
 	ctx, cancel := context.WithTimeout(b.ctx, b.config.Timeout)
 	defer cancel()
 
@@ -144,7 +141,6 @@ func (b *Browser) NavigateAndFill(url string, brokerID string, autoSubmit bool) 
 		return result, err
 	}
 
-	// Wait for page to load
 	err = chromedp.Run(ctx, chromedp.WaitReady("body"))
 	if err != nil {
 		result.ErrorMessage = fmt.Sprintf("page load failed: %v", err)

--- a/internal/browser/confirm.go
+++ b/internal/browser/confirm.go
@@ -29,7 +29,6 @@ type ConfirmationHandler struct {
 func NewConfirmationHandler(brokerDomains []string) *ConfirmationHandler {
 	domains := make(map[string]bool)
 	for _, d := range brokerDomains {
-		// Store both the domain and common variations
 		d = strings.ToLower(d)
 		domains[d] = true
 		// Also allow subdomains
@@ -82,7 +81,6 @@ func (h *ConfirmationHandler) ClickConfirmationLink(confirmURL string, validateD
 		RedirectPath: []string{confirmURL},
 	}
 
-	// Validate domain if requested
 	if validateDomain {
 		valid, domain, err := h.ValidateDomain(confirmURL)
 		if err != nil {
@@ -102,7 +100,6 @@ func (h *ConfirmationHandler) ClickConfirmationLink(confirmURL string, validateD
 		return result, err
 	}
 
-	// Set headers to look like a real browser
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.5")
@@ -143,7 +140,6 @@ func (h *ConfirmationHandler) ClickConfirmationLink(confirmURL string, validateD
 	result.FinalURL = resp.Request.URL.String()
 	result.RedirectPath = append(result.RedirectPath, redirects...)
 
-	// Read response body (limited to 64KB)
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	if err != nil {
 		result.ErrorMessage = fmt.Sprintf("failed to read response: %v", err)

--- a/internal/browser/domain.go
+++ b/internal/browser/domain.go
@@ -20,7 +20,6 @@ func matchesAllowedDomain(rawURL string, allowedDomains []string) (bool, string,
 
 	host := strings.ToLower(parsed.Host)
 
-	// Remove port if present
 	if idx := strings.Index(host, ":"); idx != -1 {
 		host = host[:idx]
 	}
@@ -35,7 +34,6 @@ func matchesAllowedDomain(rawURL string, allowedDomains []string) (bool, string,
 		return true, host, nil
 	}
 
-	// Check if it's a subdomain of a known domain
 	for domain := range domainSet {
 		if strings.HasSuffix(host, "."+domain) {
 			return true, domain, nil

--- a/internal/browser/filler.go
+++ b/internal/browser/filler.go
@@ -51,7 +51,6 @@ func NewFormFiller(profile *config.Profile) *FormFiller {
 func (f *FormFiller) Fill(ctx context.Context) *FillResult {
 	result := &FillResult{}
 
-	// Get all field mappings based on profile
 	mappings := f.getFieldMappings()
 
 	for _, mapping := range mappings {
@@ -308,7 +307,6 @@ func (f *FormFiller) fillSelector(ctx context.Context, selector string, value st
 		return f.fillSelectElement(ctx, selector, value)
 	}
 
-	// Clear existing value and fill
 	err = chromedp.Run(ctx,
 		chromedp.Clear(selector),
 		chromedp.SendKeys(selector, value),
@@ -358,7 +356,6 @@ func (f *FormFiller) fillSelectElement(ctx context.Context, selector string, val
 // fillByPattern searches for fields matching patterns. Returns (filled, err)
 // where err is non-nil only for a real failure (see fillSelector).
 func (f *FormFiller) fillByPattern(ctx context.Context, mapping FieldMapping) (bool, error) {
-	// Build JavaScript to find matching fields
 	patternsJS := "["
 	for i, p := range mapping.Patterns {
 		if i > 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -306,7 +306,6 @@ func Load(path string) (*Config, error) {
 		cfg.Options.DailySendLimit = defaultDailySendLimit
 	}
 
-	// Set inbox defaults
 	if cfg.Inbox.Folder == "" {
 		cfg.Inbox.Folder = "INBOX"
 	}
@@ -322,7 +321,6 @@ func Load(path string) (*Config, error) {
 		cfg.Inbox.Port = 993
 	}
 
-	// Set pipeline defaults
 	if cfg.Pipeline.BrowserTimeoutSec == 0 {
 		cfg.Pipeline.BrowserTimeoutSec = 30
 	}

--- a/internal/dpa/dpa.go
+++ b/internal/dpa/dpa.go
@@ -80,20 +80,6 @@ func ForCountry(name string) *Authority {
 	return nil
 }
 
-// ByRegion groups the authorities by their Region, preserving first-seen order
-// of both regions and entries.
-func ByRegion() ([]string, map[string][]Authority) {
-	var order []string
-	groups := map[string][]Authority{}
-	for _, a := range All() {
-		if _, seen := groups[a.Region]; !seen {
-			order = append(order, a.Region)
-		}
-		groups[a.Region] = append(groups[a.Region], a)
-	}
-	return order, groups
-}
-
 // Describe is a one-line "Authority (ACRONYM) - website" for CLI/report output.
 func (a Authority) Describe() string {
 	if a.Acronym != "" {

--- a/internal/dpa/dpa_test.go
+++ b/internal/dpa/dpa_test.go
@@ -49,23 +49,6 @@ func TestForCountry(t *testing.T) {
 	}
 }
 
-func TestByRegion(t *testing.T) {
-	order, groups := ByRegion()
-	if len(order) < 3 {
-		t.Fatalf("expected several regions, got %v", order)
-	}
-	if order[0] != "European Union / EEA" {
-		t.Errorf("first region = %q, want European Union / EEA", order[0])
-	}
-	total := 0
-	for _, r := range order {
-		total += len(groups[r])
-	}
-	if total != len(All()) {
-		t.Errorf("grouped %d != All() %d", total, len(All()))
-	}
-}
-
 func TestDescribe(t *testing.T) {
 	lv := ForCountry("Latvia")
 	if got := lv.Describe(); got != "Datu valsts inspekcija (Data State Inspectorate) (DVI) - https://www.dvi.gov.lv" {

--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -1,7 +1,6 @@
 package email
 
 import (
-	"context"
 	"fmt"
 	"net/mail"
 	"strings"
@@ -32,11 +31,10 @@ type Result struct {
 	Error     error
 }
 
-type Sender interface {
-	Send(ctx context.Context, msg Message) Result
-}
-
-func NewSender(cfg config.EmailConfig) (Sender, error) {
+// NewSender builds the sender for cfg. SMTP is the only provider; the check
+// exists so a stale provider: line in config.yaml fails loudly instead of
+// silently sending over SMTP anyway.
+func NewSender(cfg config.EmailConfig) (*SMTPSender, error) {
 	if cfg.Provider == "" || cfg.Provider == "smtp" {
 		return NewSMTPSender(cfg.SMTP, cfg.From), nil
 	}

--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -34,7 +34,6 @@ type Result struct {
 
 type Sender interface {
 	Send(ctx context.Context, msg Message) Result
-	Name() string
 }
 
 func NewSender(cfg config.EmailConfig) (Sender, error) {

--- a/internal/email/smtp.go
+++ b/internal/email/smtp.go
@@ -19,8 +19,6 @@ func NewSMTPSender(cfg config.SMTPConfig, from string) *SMTPSender {
 	return &SMTPSender{config: cfg, from: from}
 }
 
-func (s *SMTPSender) Name() string { return "smtp" }
-
 func (s *SMTPSender) Send(ctx context.Context, msg Message) Result {
 	if err := validateMessage(msg); err != nil {
 		return Result{Success: false, Error: err}

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -1028,7 +1028,6 @@ func (s *Store) GetFormsWithStatus(profileID string) ([]FormWithStatus, error) {
 			return nil, fmt.Errorf("failed to scan form: %w", err)
 		}
 
-		// Skip duplicates (keep first/most recent)
 		if seen[f.BrokerID] {
 			continue
 		}
@@ -1036,7 +1035,6 @@ func (s *Store) GetFormsWithStatus(profileID string) ([]FormWithStatus, error) {
 
 		f.PipelineStatus = PipelineStatus(pipelineStatus)
 
-		// Determine status based on task and pipeline status
 		if taskStatus == "completed" {
 			f.Status = "filled"
 		} else if taskStatus == "skipped" {

--- a/internal/inbox/classifier.go
+++ b/internal/inbox/classifier.go
@@ -239,10 +239,8 @@ func ClassifyResponse(email *Email) ClassifiedResponse {
 		Confidence: 0.0,
 	}
 
-	// Extract URLs from the email
 	result.URLs = ParseEmailURLs(email)
 
-	// Get the text content to analyze
 	content := email.Body
 	if content == "" {
 		content = stripHTML(email.HTMLBody)
@@ -252,7 +250,6 @@ func ClassifyResponse(email *Email) ClassifiedResponse {
 	// Also check subject
 	subject := strings.ToLower(email.Subject)
 
-	// Check if this is a test email (from Eraser itself)
 	if isTestEmail(subject, content) {
 		result.Type = ResponseSuccess
 		result.Confidence = 1.0
@@ -345,7 +342,6 @@ func ClassifyResponse(email *Email) ClassifiedResponse {
 		scores[ResponseConfirmationRequired] += 2
 	}
 
-	// Find the highest scoring type and second highest
 	maxScore := 0
 	secondScore := 0
 	for responseType, score := range scores {
@@ -393,12 +389,10 @@ func ClassifyResponse(email *Email) ClassifiedResponse {
 		}
 	}
 
-	// Set primary URLs
 	brokerDomain := email.FromDomain
 	result.FormURL = GetPrimaryFormURL(result.URLs, brokerDomain)
 	result.ConfirmURL = GetPrimaryConfirmationURL(result.URLs, brokerDomain)
 
-	// Set reason based on classification
 	result.Reason = getClassificationReason(result.Type, maxScore)
 
 	// Flag for manual review if unknown, low confidence, or an ambiguous
@@ -450,10 +444,8 @@ func stripHTML(html string) string {
 	html = htmlScriptTagRe.ReplaceAllString(html, "")
 	html = htmlStyleTagRe.ReplaceAllString(html, "")
 
-	// Remove HTML tags
 	html = htmlAnyTagRe.ReplaceAllString(html, " ")
 
-	// Decode common HTML entities
 	html = strings.ReplaceAll(html, "&nbsp;", " ")
 	html = strings.ReplaceAll(html, "&amp;", "&")
 	html = strings.ReplaceAll(html, "&lt;", "<")
@@ -519,7 +511,6 @@ func ClassifyBySubjectOnly(subject string) (ResponseType, float64, bool) {
 		}
 	}
 
-	// Find highest scoring type
 	maxScore := 0
 	bestType := ResponseUnknown
 	for responseType, score := range scores {
@@ -602,7 +593,6 @@ func isTestEmail(subject, content string) bool {
 
 // isBounceEmail checks if an email is a bounce/undeliverable notification
 func isBounceEmail(email *Email, subject, content string) bool {
-	// Check if sender looks like a mail system
 	fromLower := strings.ToLower(email.From)
 	fromNameLower := strings.ToLower(email.FromName)
 

--- a/internal/inbox/classifier_eu.go
+++ b/internal/inbox/classifier_eu.go
@@ -2,16 +2,12 @@ package inbox
 
 import "regexp"
 
-// This file extends the keyword classifier for the EU/GDPR use this fork is
-// built around. The upstream patterns in classifier.go are English and
-// CCPA-flavoured, so replies that talk about "erasure" / "Article 17" / a
-// "data protection officer", and replies in German or French (the two largest
-// EU markets, and where brokers reply in the local language), were all landing
-// as `unknown`.
-//
-// init() appends to the package-level pattern slices, so both ClassifyResponse
-// and ClassifyBySubjectOnly pick these up. Non-English patterns are kept
-// high-signal to avoid false positives against English text.
+// GDPR-vocabulary and German/French patterns for the classifier. classifier.go
+// is English/CCPA-flavoured, so "erasure" / "Article 17" replies and anything
+// in DE or FR (the biggest EU markets, where brokers reply in-language) landed
+// as unknown. init() appends to the package slices so both ClassifyResponse and
+// ClassifyBySubjectOnly use them; non-English patterns stay narrow to avoid
+// matching English text.
 
 func init() {
 	successPatterns = append(successPatterns,

--- a/internal/inbox/monitor.go
+++ b/internal/inbox/monitor.go
@@ -50,7 +50,6 @@ func NewMonitor(cfg config.InboxConfig, brokerList []broker.Broker) *Monitor {
 	// Build a map of email domains to brokers for quick lookup
 	brokerMap := make(map[string]broker.Broker)
 	for _, b := range brokerList {
-		// Extract domain from broker email
 		if b.Email != "" {
 			parts := strings.Split(b.Email, "@")
 			if len(parts) == 2 {
@@ -211,11 +210,9 @@ func (m *Monitor) FetchRecentEmails(ctx context.Context, days int) ([]Email, err
 		return nil, nil
 	}
 
-	// Fetch the messages using UIDs
 	seqSet := new(imap.SeqSet)
 	seqSet.AddNum(uids...)
 
-	// Fetch envelope, body, and UID
 	section := &imap.BodySectionName{}
 	items := []imap.FetchItem{imap.FetchEnvelope, imap.FetchFlags, imap.FetchUid, section.FetchItem()}
 
@@ -239,12 +236,10 @@ func (m *Monitor) parseMessage(msg *imap.Message, section *imap.BodySectionName)
 		ReceivedAt: msg.Envelope.Date,
 	}
 
-	// Get message ID
 	if msg.Envelope.MessageId != "" {
 		email.MessageID = msg.Envelope.MessageId
 	}
 
-	// Get sender
 	if len(msg.Envelope.From) > 0 {
 		from := msg.Envelope.From[0]
 		email.From = from.Address()
@@ -262,7 +257,6 @@ func (m *Monitor) parseMessage(msg *imap.Message, section *imap.BodySectionName)
 		}
 	}
 
-	// Parse body
 	r := msg.GetBody(section)
 	if r == nil {
 		return email, nil
@@ -273,7 +267,6 @@ func (m *Monitor) parseMessage(msg *imap.Message, section *imap.BodySectionName)
 		return email, nil // Return without body on parse error
 	}
 
-	// Process each part
 	for {
 		p, err := mr.NextPart()
 		if err == io.EOF {
@@ -360,7 +353,6 @@ func (m *Monitor) FetchBrokerEmailsFromFolder(ctx context.Context, folder string
 			seqSet.AddNum(uid)
 		}
 
-		// Fetch message details
 		section := &imap.BodySectionName{Peek: true}
 		items := []imap.FetchItem{imap.FetchEnvelope, imap.FetchUid, section.FetchItem()}
 
@@ -458,7 +450,6 @@ func (m *Monitor) WatchForNewEmails(ctx context.Context, callback func(Email)) e
 		return fmt.Errorf("failed to select mailbox: %w", err)
 	}
 
-	// Start IDLE
 	updates := make(chan client.Update)
 	m.client.Updates = updates
 
@@ -483,7 +474,6 @@ func (m *Monitor) WatchForNewEmails(ctx context.Context, callback func(Email)) e
 			switch u := update.(type) {
 			case *client.MailboxUpdate:
 				log.Printf("New mail detected: %d messages", u.Mailbox.Messages)
-				// Fetch the latest message
 				close(stop)
 				<-idleDone
 
@@ -491,7 +481,6 @@ func (m *Monitor) WatchForNewEmails(ctx context.Context, callback func(Email)) e
 				if err != nil {
 					log.Printf("Error fetching new email: %v", err)
 				} else if len(emails) > 0 {
-					// Process the newest email
 					for _, email := range emails {
 						if email.BrokerID != "" {
 							callback(email)
@@ -542,7 +531,6 @@ func (m *Monitor) EnsureFolderExists(name string) error {
 		return nil
 	}
 
-	// Create the folder
 	if err := m.client.Create(name); err != nil {
 		return fmt.Errorf("failed to create folder '%s': %w", name, err)
 	}
@@ -604,7 +592,6 @@ func (m *Monitor) ArchiveEmails(uids []uint32, folder string) error {
 			return fmt.Errorf("failed to copy emails to '%s': %w", folder, err)
 		}
 
-		// Mark as deleted
 		item := imap.FormatFlagsOp(imap.AddFlags, true)
 		flags := []interface{}{imap.DeletedFlag}
 		if err := m.client.UidStore(seqSet, item, flags, nil); err != nil {

--- a/internal/inbox/parser.go
+++ b/internal/inbox/parser.go
@@ -126,7 +126,6 @@ func ParseEmailURLs(email *Email) ExtractedURLs {
 		}
 		seen[cleanURL] = true
 
-		// Skip tracking pixels
 		if isTrackingURL(cleanURL) {
 			continue
 		}
@@ -175,7 +174,6 @@ func extractURLsFromHTML(html string) []string {
 		return extractURLsFromText(html)
 	}
 
-	// Find all links
 	doc.Find("a[href]").Each(func(i int, s *goquery.Selection) {
 		if href, exists := s.Attr("href"); exists {
 			urls = append(urls, href)
@@ -193,7 +191,6 @@ func cleanURL(rawURL string) string {
 	// Remove trailing punctuation that might have been captured
 	rawURL = strings.TrimRight(rawURL, ".,;:!?)")
 
-	// Parse to validate
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return ""
@@ -397,7 +394,6 @@ func GetPrimaryFormURL(urls ExtractedURLs, brokerDomain string) string {
 		lowerURL := strings.ToLower(u)
 		score := scoreFormURL(lowerURL)
 
-		// Skip negative scores (disqualified)
 		if score < 0 {
 			continue
 		}
@@ -434,7 +430,6 @@ func GetPrimaryConfirmationURL(urls ExtractedURLs, brokerDomain string) string {
 		}
 	}
 
-	// Return first confirmation URL if any
 	if len(urls.ConfirmationURLs) > 0 {
 		return urls.ConfirmationURLs[0]
 	}

--- a/internal/web/handlers_api.go
+++ b/internal/web/handlers_api.go
@@ -28,7 +28,6 @@ func (s *Server) handleAPIBrokers(w http.ResponseWriter, r *http.Request) {
 
 	brokers := s.getBrokersWithStatus(s.activeProfile(r).ID, search, category, region, status, missingEmail, showExcluded)
 
-	// Returns broker list as HTML fragment for HTMX
 	s.renderPartial(w, "partials/broker-list.html", map[string]interface{}{
 		"Brokers":      brokers,
 		"Filtered":     len(brokers),
@@ -194,7 +193,6 @@ func (s *Server) handleAPIResponses(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleAPIInboxScan(w http.ResponseWriter, r *http.Request) {
-	// Check if inbox is configured
 	cfg := s.getConfig()
 	if cfg == nil || !cfg.Inbox.Enabled {
 		_, _ = w.Write([]byte(`
@@ -206,10 +204,8 @@ func (s *Server) handleAPIInboxScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create inbox monitor
 	monitor := inbox.NewMonitor(cfg.Inbox, s.brokerDB.Brokers)
 
-	// Connect to IMAP
 	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
 	defer cancel()
 
@@ -278,7 +274,6 @@ func (s *Server) handleAPIInboxScan(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// Store in database
 		brokerResp := &history.BrokerResponse{
 			ProfileID:    profileID,
 			BrokerID:     email.BrokerID,
@@ -330,7 +325,6 @@ func (s *Server) handleAPIInboxScan(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Return summary HTML
 	_, _ = fmt.Fprintf(w, `
 		<div class="bg-green-100 border border-green-400 text-green-800 px-4 py-3 rounded">
 			<strong>Scan complete!</strong> Found %d broker emails.
@@ -351,7 +345,6 @@ func (s *Server) handleAPIInboxScan(w http.ResponseWriter, r *http.Request) {
 
 // handleAPIInboxRescan rescans all emails and reclassifies them with the improved classifier
 func (s *Server) handleAPIInboxRescan(w http.ResponseWriter, r *http.Request) {
-	// Check if inbox is configured
 	cfg := s.getConfig()
 	if cfg == nil || !cfg.Inbox.Enabled {
 		_, _ = w.Write([]byte(`
@@ -363,7 +356,6 @@ func (s *Server) handleAPIInboxRescan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if clear flag is set
 	clearFirst := r.URL.Query().Get("clear") == "true"
 	if clearFirst && s.historyStore != nil {
 		if err := s.historyStore.ClearBrokerResponses(); err != nil {
@@ -376,10 +368,8 @@ func (s *Server) handleAPIInboxRescan(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Create inbox monitor
 	monitor := inbox.NewMonitor(cfg.Inbox, s.brokerDB.Brokers)
 
-	// Connect to IMAP with longer timeout for full rescan
 	ctx, cancel := context.WithTimeout(r.Context(), 180*time.Second)
 	defer cancel()
 
@@ -447,11 +437,9 @@ func (s *Server) handleAPIInboxRescan(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// Check if this response already exists
 		if s.historyStore != nil {
 			existing, _ := s.historyStore.FindBrokerResponseBySubject(profileID, email.BrokerID, email.Subject)
 			if existing != nil {
-				// Update existing response classification
 				err := s.historyStore.UpdateBrokerResponseClassification(
 					existing.ID,
 					existing.ProfileID,
@@ -513,7 +501,6 @@ func (s *Server) handleAPIInboxRescan(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Return summary HTML
 	_, _ = fmt.Fprintf(w, `
 		<div class="bg-green-100 border border-green-400 text-green-800 px-4 py-3 rounded">
 			<strong>Rescan complete!</strong> Processed %d broker emails.
@@ -548,7 +535,6 @@ func (s *Server) handleAPIReclassify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get all broker responses
 	responses, err := s.historyStore.GetAllBrokerResponses()
 	if err != nil {
 		_, _ = fmt.Fprintf(w, `
@@ -595,7 +581,6 @@ func (s *Server) handleAPIReclassify(w http.ResponseWriter, r *http.Request) {
 			// Fetch emails from both INBOX and archive folder
 			var allEmails []inbox.Email
 
-			// Fetch from INBOX
 			emails, err := monitor.FetchRecentEmails(ctx, 30) // 30 days
 			if err != nil {
 				log.Printf("Warning: failed to fetch from INBOX: %v", err)
@@ -631,7 +616,6 @@ func (s *Server) handleAPIReclassify(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			// Update database records with missing bodies
 			for _, resp := range responses {
 				if resp.EmailBody != "" {
 					continue // Already has body
@@ -720,7 +704,6 @@ func (s *Server) handleAPIReclassify(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Return summary HTML
 	_, _ = fmt.Fprintf(w, `
 		<div class="bg-green-100 border border-green-400 text-green-800 px-4 py-3 rounded">
 			<strong>Reclassification complete!</strong> Processed %d records.

--- a/internal/web/handlers_jobs.go
+++ b/internal/web/handlers_jobs.go
@@ -312,7 +312,7 @@ func effectiveDailyLimit(cfg *config.Config) int {
 }
 
 // processSendJob runs in a background goroutine to send emails
-func (s *Server) processSendJob(job *Job, toSend []BrokerWithStatus, sender email.Sender) {
+func (s *Server) processSendJob(job *Job, toSend []BrokerWithStatus, sender *email.SMTPSender) {
 	sent := 0
 	failed := 0
 
@@ -480,7 +480,7 @@ func (s *Server) handleAPIJobActive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = json.NewEncoder(w).Encode(map[string]interface{}{"job": job.ToJSON()})
+	_ = json.NewEncoder(w).Encode(map[string]any{"job": job})
 }
 
 // handleAPIJobStatus returns the status of a specific job
@@ -499,7 +499,7 @@ func (s *Server) handleAPIJobStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = json.NewEncoder(w).Encode(job.ToJSON())
+	_ = json.NewEncoder(w).Encode(job)
 }
 
 // handleAPIJobCancel cancels a running job

--- a/internal/web/handlers_jobs.go
+++ b/internal/web/handlers_jobs.go
@@ -48,7 +48,6 @@ func (s *Server) resumePendingJob(state *PersistentJobState) {
 		return
 	}
 
-	// Create email sender
 	sender, err := email.NewSender(cfg.Email)
 	if err != nil {
 		log.Printf("Cannot resume job: failed to create email sender: %v", err)
@@ -56,7 +55,6 @@ func (s *Server) resumePendingJob(state *PersistentJobState) {
 		return
 	}
 
-	// Build broker list from remaining IDs
 	brokerMap := make(map[string]broker.Broker)
 	for _, b := range s.brokerDB.Brokers {
 		brokerMap[b.ID] = b
@@ -88,7 +86,6 @@ func (s *Server) resumePendingJob(state *PersistentJobState) {
 
 	fmt.Printf("Resuming send job: %d brokers remaining...\n", len(toSend))
 
-	// Process remaining brokers
 	s.processSendJob(job, toSend, sender)
 }
 
@@ -122,7 +119,6 @@ func (s *Server) handleAPISendOne(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create email sender
 	sender, err := email.NewSender(cfg.Email)
 	if err != nil {
 		_, _ = fmt.Fprintf(w, `<span class="text-red-600">Error: %s</span>`, template.HTMLEscapeString(err.Error()))
@@ -201,7 +197,6 @@ func (s *Server) handleAPISendAll(w http.ResponseWriter, r *http.Request) {
 
 	activeProfile := s.activeProfile(r)
 
-	// Check if a job is already running for this profile
 	if activeJob := s.jobManager.GetActive(activeProfile.ID); activeJob != nil {
 		w.WriteHeader(http.StatusConflict)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -218,7 +213,6 @@ func (s *Server) handleAPISendAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get filter parameters from form
 	limitFormBody(w, r)
 	search := r.FormValue("search")
 	category := r.FormValue("category")
@@ -254,16 +248,13 @@ func (s *Server) handleAPISendAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create a new job
 	job := s.jobManager.Create(len(toSend), activeProfile.ID)
 
-	// Extract broker IDs for persistence
 	brokerIDs := make([]string, len(toSend))
 	for i, b := range toSend {
 		brokerIDs[i] = b.ID
 	}
 
-	// Save initial job state
 	jobState := &PersistentJobState{
 		ID:               job.ID,
 		ProfileID:        activeProfile.ID,
@@ -282,10 +273,8 @@ func (s *Server) handleAPISendAll(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Warning: failed to save job state: %v", err)
 	}
 
-	// Start background goroutine to process emails
 	go s.processSendJob(job, toSend, sender)
 
-	// Return job ID immediately
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"job_id": job.ID,
 		"total":  len(toSend),
@@ -349,7 +338,6 @@ func (s *Server) processSendJob(job *Job, toSend []BrokerWithStatus, sender *ema
 	}
 
 	for i, b := range toSend {
-		// Check if job was cancelled
 		if job.IsCancelled() {
 			break
 		}
@@ -362,7 +350,6 @@ func (s *Server) processSendJob(job *Job, toSend []BrokerWithStatus, sender *ema
 			return
 		}
 
-		// Update current broker
 		job.Update(sent, failed, b.Name, b.ID)
 
 		// Generate email using the user's configured template (see the
@@ -371,7 +358,6 @@ func (s *Server) processSendJob(job *Job, toSend []BrokerWithStatus, sender *ema
 		if err != nil {
 			failed++
 			job.Update(sent, failed, b.Name, b.ID)
-			// Remove from remaining even on failure
 			remaining = remaining[1:]
 			s.saveJobProgress(job, sent, failed, remaining)
 			continue
@@ -416,7 +402,6 @@ func (s *Server) processSendJob(job *Job, toSend []BrokerWithStatus, sender *ema
 			// Check for auth failures and stop if too many consecutive
 			if strings.Contains(strings.ToLower(errMsg), "auth") {
 				if job.RecordAuthFailure() {
-					// Stop job due to auth errors
 					if s.historyStore != nil {
 						_ = s.historyStore.Add(record)
 					}
@@ -433,7 +418,6 @@ func (s *Server) processSendJob(job *Job, toSend []BrokerWithStatus, sender *ema
 			_ = s.historyStore.Add(record)
 		}
 
-		// Update job progress
 		job.Update(sent, failed, b.Name, b.ID)
 
 		// Remove processed broker from remaining and save state
@@ -446,7 +430,6 @@ func (s *Server) processSendJob(job *Job, toSend []BrokerWithStatus, sender *ema
 		}
 	}
 
-	// Mark job as complete and clear persisted state
 	job.Complete()
 	if err := s.jobPersistence.Clear(); err != nil {
 		log.Printf("Warning: failed to clear job state: %v", err)

--- a/internal/web/handlers_pages.go
+++ b/internal/web/handlers_pages.go
@@ -13,7 +13,6 @@ import (
 // Handler implementations
 
 func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
-	// Check if config exists, redirect to setup if not
 	cfg := s.getConfig()
 	if cfg == nil || cfg.Profile.FirstName == "" && len(cfg.Profiles) == 0 {
 		http.Redirect(w, r, "/setup", http.StatusFound)
@@ -113,7 +112,6 @@ func (s *Server) getPipelineStats(profileID string) PipelineStats {
 		return stats
 	}
 
-	// Get pipeline stage counts
 	pipelineStats, err := s.historyStore.GetPipelineStats(profileID)
 	if err == nil {
 		stats.EmailSent = pipelineStats[history.PipelineEmailSent]
@@ -128,13 +126,11 @@ func (s *Server) getPipelineStats(profileID string) PipelineStats {
 		stats.Failed = pipelineStats[history.PipelineFailed]
 	}
 
-	// Get pending tasks count (CAPTCHAs, etc.)
 	pendingTaskCount, _, _, err := s.historyStore.GetPendingTaskStats(profileID)
 	if err == nil {
 		stats.PendingTasks = pendingTaskCount
 	}
 
-	// Get needs review count
 	responses, err := s.historyStore.GetBrokerResponses(profileID, "", true, 1000)
 	if err == nil {
 		stats.NeedsReview = len(responses)
@@ -198,7 +194,6 @@ func (s *Server) handleFormComplete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update pipeline status to confirmed
 	if err := s.historyStore.UpdatePipelineStatus(s.activeProfile(r).ID, brokerID, history.PipelineConfirmed); err != nil {
 		http.Error(w, "Failed to update status", http.StatusInternalServerError)
 		return
@@ -222,7 +217,6 @@ func (s *Server) handleFormSkip(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update pipeline status to rejected (skipped)
 	if err := s.historyStore.UpdatePipelineStatus(s.activeProfile(r).ID, brokerID, history.PipelineRejected); err != nil {
 		http.Error(w, "Failed to update status", http.StatusInternalServerError)
 		return
@@ -260,17 +254,14 @@ func (s *Server) handleTasks(w http.ResponseWriter, r *http.Request) {
 		tasks, _ = s.historyStore.GetPendingTasks(active.ID, history.TaskType(taskType), "pending")
 		completedTasksList, _ = s.historyStore.GetPendingTasks(active.ID, history.TaskType(taskType), "completed")
 		forms, _ = s.historyStore.GetFormsWithStatus(active.ID)
-		// Get items needing review (parser was unsure)
 		reviewItems, _ = s.historyStore.GetBrokerResponses(active.ID, "", true, 1000)
 	}
 
-	// Get task stats
 	pendingTasks, completedTasksCount, skippedTasks := 0, 0, 0
 	if s.historyStore != nil {
 		pendingTasks, completedTasksCount, skippedTasks, _ = s.historyStore.GetPendingTaskStats(active.ID)
 	}
 
-	// Get form stats
 	pendingForms, filledForms, captchaForms, failedForms, skippedForms := 0, 0, 0, 0, 0
 	if s.historyStore != nil {
 		pendingForms, filledForms, captchaForms, failedForms, skippedForms, _ = s.historyStore.GetFormStats(active.ID)
@@ -283,7 +274,6 @@ func (s *Server) handleTasks(w http.ResponseWriter, r *http.Request) {
 	// This avoids double-counting captcha items
 	totalActionItems := pendingForms + pendingTasks
 
-	// Get items needing review count
 	needsReviewCount := len(reviewItems)
 
 	data := map[string]interface{}{
@@ -406,13 +396,11 @@ func (s *Server) handleTaskHelper(w http.ResponseWriter, r *http.Request) {
 	// Re-fetch task to get updated opened_at
 	task, _ = s.historyStore.GetPendingTaskByID(taskID, activeProfileID)
 
-	// Parse profile data from BrowserState (JSON)
 	profileData := make(map[string]string)
 	if task.BrowserState != "" {
 		_ = json.Unmarshal([]byte(task.BrowserState), &profileData)
 	}
 
-	// Create ordered profile fields for display
 	orderedFields := []struct {
 		Key   string
 		Label string
@@ -428,7 +416,6 @@ func (s *Server) handleTaskHelper(w http.ResponseWriter, r *http.Request) {
 		{"country", "Country"},
 	}
 
-	// Build ordered map for template
 	orderedProfile := make([]map[string]string, 0)
 	for _, field := range orderedFields {
 		if val, ok := profileData[field.Key]; ok && val != "" {

--- a/internal/web/handlers_settings.go
+++ b/internal/web/handlers_settings.go
@@ -24,7 +24,6 @@ func (s *Server) handleSettingsInbox(w http.ResponseWriter, r *http.Request) {
 	email := r.FormValue("inbox_email")
 	password := r.FormValue("inbox_password")
 
-	// Validate required fields
 	if email == "" || password == "" {
 		s.renderSettingsWithMessage(w, r, "Email and password are required", false)
 		return
@@ -71,7 +70,6 @@ func (s *Server) handleSettingsInbox(w http.ResponseWriter, r *http.Request) {
 	}
 	newCfg.Inbox = inbox
 
-	// Save config
 	if err := config.Save(s.configPath, &newCfg); err != nil {
 		s.renderSettingsWithMessage(w, r, "Failed to save configuration: "+err.Error(), false)
 		return

--- a/internal/web/handlers_setup.go
+++ b/internal/web/handlers_setup.go
@@ -95,14 +95,12 @@ func (s *Server) handleSetupEmail(w http.ResponseWriter, r *http.Request) {
 
 		errors := make(map[string]string)
 
-		// Parse SMTP configuration (Gmail SMTP)
 		emailCfg.SMTP.Host = strings.TrimSpace(r.FormValue("smtp_host"))
 		_, _ = fmt.Sscanf(r.FormValue("smtp_port"), "%d", &emailCfg.SMTP.Port)
 		emailCfg.SMTP.Username = strings.TrimSpace(r.FormValue("smtp_username"))
 		emailCfg.SMTP.Password = strings.TrimSpace(r.FormValue("smtp_password"))
 		emailCfg.SMTP.UseTLS = r.FormValue("smtp_tls") == "on"
 
-		// Validate required fields
 		if emailCfg.SMTP.Host == "" {
 			errors["smtp_host"] = "SMTP host is required"
 		}
@@ -141,7 +139,6 @@ func (s *Server) handleSetupEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set Gmail defaults for new setups
 	emailCfg := session.Email
 	if emailCfg.SMTP.Host == "" {
 		emailCfg.SMTP.Host = "smtp.gmail.com"
@@ -188,7 +185,6 @@ func (s *Server) handleSetupTestSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create email sender with the session config
 	sender, err := email.NewSender(session.Email)
 	if err != nil {
 		_, _ = fmt.Fprintf(w, `
@@ -200,7 +196,6 @@ func (s *Server) handleSetupTestSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Send test email
 	testMsg := email.Message{
 		To:      session.Profile.Email,
 		From:    session.Email.From,
@@ -287,7 +282,6 @@ func (s *Server) handleSetupComplete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update server's config reference
 	s.config.Store(cfg)
 
 	// Clear session - credentials are now saved to config file
@@ -314,7 +308,6 @@ func (s *Server) getOrCreateSession(w http.ResponseWriter, r *http.Request) *Ses
 		}
 	}
 
-	// Create new session
 	sessionID, err := s.sessions.Create()
 	if err != nil {
 		return nil

--- a/internal/web/handlers_setup.go
+++ b/internal/web/handlers_setup.go
@@ -331,12 +331,10 @@ func (s *Server) getOrCreateSession(w http.ResponseWriter, r *http.Request) *Ses
 		// Note: Secure flag omitted for localhost HTTP; add for production HTTPS
 	})
 
-	// Also attach the cookie to the *incoming* request so a later
-	// getSession/updateSession(r) call within this same request sees the
-	// brand-new session. Without this, the first POST /setup/profile creates
-	// the session but the immediately-following updateSession(r) can't find
-	// it, so the profile is never stored and the wizard bounces back to step
-	// one on a fresh install.
+	// Attach to the incoming request too: handleSetupProfile calls
+	// updateSession(r) right after this, and on a fresh install r has no
+	// session cookie yet - without this the profile never persists and the
+	// wizard loops back to step one.
 	r.AddCookie(&http.Cookie{Name: "eraser_session", Value: sessionID})
 
 	return s.sessions.Get(sessionID)

--- a/internal/web/job.go
+++ b/internal/web/job.go
@@ -90,8 +90,8 @@ func (j *Job) StopWithError(errorType, errorMsg string) {
 
 // Pause marks the job paused (daily send limit reached) with the given
 // day-sent count and message, all under one lock - processSendJob used to
-// set these three fields directly, racing with any concurrent read (e.g.
-// ToJSON on a status-polling request).
+// set these three fields directly, racing with any concurrent read (e.g. a
+// status poll marshalling the job).
 func (j *Job) Pause(daySent int, errorMsg string) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
@@ -167,28 +167,14 @@ func (j *Job) Context() context.Context {
 	return j.ctx
 }
 
-// ToJSON returns the job data for JSON serialization
-func (j *Job) ToJSON() map[string]interface{} {
+// MarshalJSON snapshots the job under the lock, so a status poll can't read a
+// half-updated Job while processSendJob is mid-Update. The exported fields'
+// json tags do the rest.
+func (j *Job) MarshalJSON() ([]byte, error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
-
-	return map[string]interface{}{
-		"id":                j.ID,
-		"profile_id":        j.ProfileID,
-		"status":            j.Status,
-		"progress":          j.Progress,
-		"sent":              j.Sent,
-		"failed":            j.Failed,
-		"total":             j.Total,
-		"current_broker":    j.CurrentBroker,
-		"current_broker_id": j.CurrentBrokerID,
-		"started_at":        j.StartedAt,
-		"completed_at":      j.CompletedAt,
-		"error":             j.Error,
-		"error_type":        j.ErrorType,
-		"daily_limit":       j.DailyLimit,
-		"day_sent":          j.DaySent,
-	}
+	type alias Job // no MarshalJSON method -> plain struct marshal, no recursion
+	return json.Marshal((*alias)(j))
 }
 
 // JobManager manages background jobs

--- a/internal/web/job_test.go
+++ b/internal/web/job_test.go
@@ -1,16 +1,40 @@
 package web
 
 import (
+	"encoding/json"
 	"sync"
 	"testing"
 )
 
+// jobSnap is the subset of a job's JSON a status poll checks.
+type jobSnap struct {
+	Sent            int    `json:"sent"`
+	Failed          int    `json:"failed"`
+	Progress        int    `json:"progress"`
+	Total           int    `json:"total"`
+	DailyLimit      int    `json:"daily_limit"`
+	CurrentBroker   string `json:"current_broker"`
+	CurrentBrokerID string `json:"current_broker_id"`
+}
+
+func readJob(t *testing.T, j *Job) jobSnap {
+	t.Helper()
+	b, err := json.Marshal(j) // locks via Job.MarshalJSON
+	if err != nil {
+		t.Fatalf("marshal job: %v", err)
+	}
+	var s jobSnap
+	if err := json.Unmarshal(b, &s); err != nil {
+		t.Fatalf("unmarshal job: %v", err)
+	}
+	return s
+}
+
 // TestJobConcurrentUpdateAndReadIsConsistent hammers Job.Update,
-// Job.SetDailyLimit, and Job.ToJSON (what a status-polling request reads)
-// from many goroutines at once and checks that every snapshot ToJSON
-// produces is internally consistent: Progress always matches the formula
-// applied to that same snapshot's Sent/Failed/Total, never a value carried
-// over from a different, interleaved call. This is the invariant that
+// Job.SetDailyLimit, and a status-poll marshal from many goroutines at once
+// and checks every snapshot is internally consistent: Progress always matches
+// the formula applied to that same snapshot's Sent/Failed/Total, never a value
+// carried over from a different, interleaved call. This is the invariant that
 // resumePendingJob/processSendJob used to violate by assigning
 // job.Sent/job.Failed/job.Progress directly instead of going through the
 // mutex-protected Update method. Run with `go test -race`.
@@ -63,19 +87,15 @@ func TestJobConcurrentUpdateAndReadIsConsistent(t *testing.T) {
 			default:
 			}
 
-			snap := job.ToJSON()
-			sent := snap["sent"].(int)
-			failed := snap["failed"].(int)
-			progress := snap["progress"].(int)
-			total := snap["total"].(int)
+			snap := readJob(t, job)
 
 			wantProgress := 0
-			if total > 0 {
-				wantProgress = ((sent + failed) * 100) / total
+			if snap.Total > 0 {
+				wantProgress = ((snap.Sent + snap.Failed) * 100) / snap.Total
 			}
-			if progress != wantProgress {
+			if snap.Progress != wantProgress {
 				t.Errorf("torn snapshot: sent=%d failed=%d total=%d progress=%d, want progress=%d",
-					sent, failed, total, progress, wantProgress)
+					snap.Sent, snap.Failed, snap.Total, snap.Progress, wantProgress)
 				return
 			}
 		}
@@ -95,34 +115,22 @@ func TestJobUpdateSetsAllFieldsUnderOneLock(t *testing.T) {
 	job := jm.Create(10, "profile-a")
 
 	job.Update(3, 2, "broker-y", "broker-y-id")
-	snap := job.ToJSON()
-	if got, want := snap["sent"].(int), 3; got != want {
-		t.Errorf("sent = %d, want %d", got, want)
+	snap := readJob(t, job)
+	if snap.Sent != 3 || snap.Failed != 2 || snap.Progress != 50 { // (3+2)*100/10
+		t.Errorf("after Update: %+v", snap)
 	}
-	if got, want := snap["failed"].(int), 2; got != want {
-		t.Errorf("failed = %d, want %d", got, want)
-	}
-	if got, want := snap["progress"].(int), 50; got != want { // (3+2)*100/10
-		t.Errorf("progress = %d, want %d", got, want)
-	}
-	if got, want := snap["current_broker"].(string), "broker-y"; got != want {
-		t.Errorf("current_broker = %q, want %q", got, want)
-	}
-	if got, want := snap["current_broker_id"].(string), "broker-y-id"; got != want {
-		t.Errorf("current_broker_id = %q, want %q", got, want)
+	if snap.CurrentBroker != "broker-y" || snap.CurrentBrokerID != "broker-y-id" {
+		t.Errorf("after Update: %+v", snap)
 	}
 
 	job.SetDailyLimit(42)
-	snap = job.ToJSON()
-	if got, want := snap["daily_limit"].(int), 42; got != want {
-		t.Errorf("daily_limit = %d, want %d", got, want)
+	snap = readJob(t, job)
+	if snap.DailyLimit != 42 {
+		t.Errorf("daily_limit = %d, want 42", snap.DailyLimit)
 	}
 	// SetDailyLimit must not have disturbed Sent/Failed/Progress.
-	if got, want := snap["sent"].(int), 3; got != want {
-		t.Errorf("sent after SetDailyLimit = %d, want %d", got, want)
-	}
-	if got, want := snap["progress"].(int), 50; got != want {
-		t.Errorf("progress after SetDailyLimit = %d, want %d", got, want)
+	if snap.Sent != 3 || snap.Progress != 50 {
+		t.Errorf("SetDailyLimit disturbed progress fields: %+v", snap)
 	}
 }
 

--- a/internal/web/routes_smoke_test.go
+++ b/internal/web/routes_smoke_test.go
@@ -41,9 +41,8 @@ func smokeServer(t *testing.T) *Server {
 	return s
 }
 
-// bodyLooksLikeTemplateError reports whether the response body carries a
-// signature of a broken html/template render (a missing key, an unclosed
-// action, a failed method call) rather than a real page.
+// bodyLooksLikeTemplateError catches a broken html/template render leaking into
+// the response instead of a real page.
 func bodyLooksLikeTemplateError(body string) (string, bool) {
 	for _, sig := range []string{
 		"Template error",

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -217,7 +217,6 @@ func (s *Server) parseTemplates() (map[string]*template.Template, error) {
 		},
 	}
 
-	// Read layout template
 	layoutContent, err := templatesFS.ReadFile("templates/layout.html")
 	if err != nil {
 		return nil, fmt.Errorf("failed to read layout template: %w", err)
@@ -249,7 +248,6 @@ func (s *Server) parseTemplates() (map[string]*template.Template, error) {
 		if err != nil {
 			return err
 		}
-		// Skip directories, partials, and layout
 		if d.IsDir() || strings.Contains(path, "/partials/") || path == "templates/layout.html" {
 			return nil
 		}
@@ -262,11 +260,9 @@ func (s *Server) parseTemplates() (map[string]*template.Template, error) {
 			return fmt.Errorf("failed to read template %s: %w", path, err)
 		}
 
-		// Create a new template for this page
 		name := path[len("templates/"):]
 		pageTmpl := template.New(name).Funcs(funcs)
 
-		// Parse layout first
 		_, err = pageTmpl.Parse(string(layoutContent))
 		if err != nil {
 			return fmt.Errorf("failed to parse layout for %s: %w", name, err)
@@ -287,7 +283,6 @@ func (s *Server) parseTemplates() (map[string]*template.Template, error) {
 			return fmt.Errorf("failed to parse template %s: %w", name, err)
 		}
 
-		// Store in map
 		templates[name] = pageTmpl
 
 		return nil
@@ -329,7 +324,6 @@ func (s *Server) Start() error {
 	// Check for pending job and offer to resume
 	s.checkPendingJob()
 
-	// Open browser after a short delay
 	go func() {
 		time.Sleep(500 * time.Millisecond)
 		url := fmt.Sprintf("http://localhost:%d", s.port)
@@ -392,7 +386,6 @@ func (s *Server) setupRouter() *chi.Mux {
 	r.Post("/forms/{brokerID}/complete", s.handleFormComplete)
 	r.Post("/forms/{brokerID}/skip", s.handleFormSkip)
 
-	// Setup wizard routes
 	r.Route("/setup", func(r chi.Router) {
 		r.Get("/", s.handleSetupWelcome)
 		r.Get("/profile", s.handleSetupProfile)
@@ -465,7 +458,6 @@ func securityHeaders(next http.Handler) http.Handler {
 			w.Header().Set("Expires", "0")
 		}
 
-		// Disable unnecessary browser features
 		w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=()")
 
 		next.ServeHTTP(w, r)
@@ -708,7 +700,6 @@ func (s *Server) renderPartial(w http.ResponseWriter, name string, data interfac
 		http.Error(w, "Template not found: "+name, http.StatusInternalServerError)
 		return
 	}
-	// Execute the template directly without layout wrapper
 	err := tmpl.Execute(w, data)
 	if err != nil {
 		http.Error(w, "Template error: "+err.Error(), http.StatusInternalServerError)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -361,14 +361,9 @@ func (s *Server) setupRouter() *chi.Mux {
 	r.Use(middleware.Compress(5))
 	r.Use(securityHeaders)
 
-	// CSRF protection. filippo.io/csrf/gorilla enforces same-origin requests
-	// via the browser's Sec-Fetch-Site / Origin headers rather than tokens or
-	// cookies (see https://go.dev/issue/73626). It "just works" for a
-	// loopback plaintext server - no TrustedOrigins / PlaintextHTTPRequest
-	// needed - and, being a different module, isn't affected by
-	// CVE-2025-47909 in the unmaintained github.com/gorilla/csrf. The
-	// per-form {{.CSRFField}} still renders (a stub value, ignored) so no
-	// template changes were needed.
+	// filippo.io/csrf enforces same-origin via Sec-Fetch-Site, not tokens, so
+	// it needs no TrustedOrigins tuning for a loopback plaintext server - and
+	// isn't the unmaintained gorilla/csrf carrying CVE-2025-47909.
 	r.Use(csrf.Protect(s.csrfKey))
 
 	// Static files
@@ -721,11 +716,8 @@ func (s *Server) renderPartial(w http.ResponseWriter, name string, data interfac
 }
 
 func (s *Server) renderWithCSRF(w http.ResponseWriter, r *http.Request, name string, data map[string]interface{}) {
-	// filippo.io/csrf/gorilla enforces same-origin via Sec-Fetch-Site and
-	// ignores tokens entirely, so there is nothing meaningful to put here.
-	// Keep the keys populated (empty) so the form templates' {{.CSRFField}} /
-	// {{.CSRFToken}} keep rendering without a change, and any HTMX code that
-	// reads the meta tag still finds it.
+	// filippo.io/csrf ignores tokens; keep the keys empty so templates
+	// rendering {{.CSRFField}} / {{.CSRFToken}} don't break.
 	data["CSRFToken"] = ""
 	data["CSRFField"] = template.HTML("")
 

--- a/internal/web/session.go
+++ b/internal/web/session.go
@@ -35,7 +35,6 @@ func NewSessionStore(ttl time.Duration) *SessionStore {
 		ttl:      ttl,
 	}
 
-	// Start background cleanup goroutine
 	go store.cleanupLoop()
 
 	return store
@@ -85,7 +84,6 @@ func (s *SessionStore) Get(id string) *Session {
 		return nil
 	}
 
-	// Check if expired
 	if time.Now().After(session.ExpiresAt) {
 		s.Delete(id)
 		return nil
@@ -104,13 +102,11 @@ func (s *SessionStore) Update(id string, updateFn func(*Session)) bool {
 		return false
 	}
 
-	// Check if expired
 	if time.Now().After(session.ExpiresAt) {
 		delete(s.sessions, id)
 		return false
 	}
 
-	// Apply updates
 	updateFn(session)
 
 	// Extend expiry

--- a/scripts/import-registries/main.go
+++ b/scripts/import-registries/main.go
@@ -36,6 +36,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -52,7 +53,6 @@ func main() {
 	gvl := flag.String("gvl", "", "path or URL to the IAB TCF Global Vendor List JSON (e.g. https://vendor-list.consensu.org/v3/vendor-list.json)")
 	gvlAll := flag.Bool("gvl-all", false, "with -gvl, include every active vendor, not just those declaring identifiable data (profiles, user-provided data, auth identifiers)")
 	region := flag.String("region", "", "region to stamp on new entries (default: us for -csv, global for -gvl)")
-	note := flag.String("note", "", "override the Notes string on new entries")
 	outDir := flag.String("out", ".", "directory for candidates.yaml + review.md")
 	flag.Parse()
 
@@ -84,9 +84,6 @@ func main() {
 	}
 	if *region != "" {
 		defRegion = *region
-	}
-	if *note != "" {
-		defNote = *note
 	}
 
 	existing, err := broker.Load("")
@@ -221,10 +218,18 @@ type gvl struct {
 	} `json:"vendors"`
 }
 
-// TCF data categories that mean the vendor can plausibly tie data to an
+// TCF data categories where the vendor can plausibly tie data to an
 // identifiable person (so a GDPR erasure request has something to act on):
 // 5 auth-derived identifiers, 7 user-provided data, 10 users' profiles.
-var identifiableDataCats = map[int]bool{5: true, 7: true, 10: true}
+func declaresIdentifiableData(cats []int) bool {
+	return slices.ContainsFunc(cats, func(c int) bool { return c == 5 || c == 7 || c == 10 })
+}
+
+// builds ad profiles under consent or legitimate interest (TCF purpose 3 or 4).
+func buildsAdProfiles(purposes, legInt []int) bool {
+	has := func(p []int) bool { return slices.Contains(p, 3) || slices.Contains(p, 4) }
+	return has(purposes) || has(legInt)
+}
 
 func readGVL(src string, includeAll bool) ([]row, error) {
 	var raw []byte
@@ -259,21 +264,11 @@ func readGVL(src string, includeAll bool) ([]row, error) {
 		if v.DeletedDate != "" || v.Name == "" {
 			continue
 		}
-		// Only vendors that build or use advertising profiles.
-		if !containsAny(v.Purposes, 3, 4) && !containsAny(v.LegIntPurposes, 3, 4) {
+		if !buildsAdProfiles(v.Purposes, v.LegIntPurposes) {
 			continue
 		}
-		if !includeAll {
-			ident := false
-			for _, c := range v.DataDeclaration {
-				if identifiableDataCats[c] {
-					ident = true
-					break
-				}
-			}
-			if !ident {
-				continue
-			}
+		if !includeAll && !declaresIdentifiableData(v.DataDeclaration) {
+			continue
 		}
 		privacy := ""
 		for _, u := range v.URLs {
@@ -288,17 +283,6 @@ func readGVL(src string, includeAll bool) ([]row, error) {
 		})
 	}
 	return out, nil
-}
-
-func containsAny(haystack []int, needles ...int) bool {
-	for _, h := range haystack {
-		for _, n := range needles {
-			if h == n {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 var nonAlnum = regexp.MustCompile(`[^a-z0-9]+`)


### PR DESCRIPTION
Three passes on the `review-cleanup` branch: ponytail-review over the v0.3.x diff, ponytail-audit repo-wide, then a repo-wide humanize-comments pass.

## 1 — diff cleanups (since v0.2.0)

- `broker.Validate` returns `(*BrokerDatabase, error)` — `validate-brokers` and `update-brokers` each re-parsed the bytes right after it.
- `import-registries`: `containsAny` → `slices.Contains`/`ContainsFunc`; dropped the unused `-note` flag.
- `broker.go`: `strconv.Quote` → `%q` (drops the import).
- Five paragraph-length comments trimmed to lines.

## 2 — repo-wide audit

- `dpa.ByRegion` (+ `TestByRegion`) — only the test called it.
- `email.Sender.Name()` / `SMTPSender.Name()` — no callers since SendGrid/Resend were removed.
- `Job.ToJSON()` — 16-key hand-built map replaced with `Job.MarshalJSON()` + a `type alias Job`; the struct already had json tags, the map only existed for the lock.
- `email.Sender` — one method, one impl, no test double. `NewSender` returns `*SMTPSender` now.

## 3 — humanize-comments (comments only, no code)

Removed **~180** comments across 26 files that only paraphrase the line beneath them — `// Get pipeline stage counts` above `x := s.getPipelineStats(...)`, `// Create new session`, `// Check if expired`, `// Read layout template`, etc. Kept every doc comment on an exported symbol, every comment giving a *reason* / deadline / foot-gun / ticket ref, and section markers inside genuinely long functions.

---

`go build` / `vet` / `gofmt` / `go test ./...` / `go test -race ./internal/web/...` / `golangci-lint` / `staticcheck` all pass; `deadcode` clean; importer output byte-identical. Net across the branch: ~-235 lines, 0 deps.