### PR TITLE
feat(seo): sitemap reference in robots.txt + OG/JSON-LD metadata

### DIFF
--- a/site/layouts/baseof.html
+++ b/site/layouts/baseof.html
@@ -9,6 +9,7 @@
 <title>{{ if .IsHome }}Eraser — data broker removal{{ else }}{{ .Title }} · Eraser{{ end }}</title>
 <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
 <link rel="canonical" href="{{ .Permalink }}">
+{{ partial "head-seo.html" . }}
 <link rel="stylesheet" href="{{ "css/site.css" | relURL }}">
 </head>
 <body>

--- a/site/layouts/partials/head-seo.html
+++ b/site/layouts/partials/head-seo.html
@@ -1,0 +1,51 @@
+{{- /* Open Graph, Twitter card and JSON-LD. Kept in one partial so baseof.html
+       stays readable and the publisher Organization is defined once. */ -}}
+{{- $isHome := .IsHome -}}
+{{- $title := cond $isHome "Eraser — data broker removal" (printf "%s · Eraser" .Title) -}}
+{{- $desc := or .Description .Site.Params.description -}}
+{{- $org := dict "@type" "Organization" "name" "Drum and Bytes" "url" "https://drumandbytes.com" -}}
+<meta property="og:type" content="{{ cond .IsPage "article" "website" }}">
+<meta property="og:site_name" content="Eraser">
+<meta property="og:title" content="{{ $title }}">
+<meta property="og:description" content="{{ $desc }}">
+<meta property="og:url" content="{{ .Permalink }}">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="{{ $title }}">
+<meta name="twitter:description" content="{{ $desc }}">
+{{- $ld := dict -}}
+{{- if $isHome -}}
+  {{- $ld = dict
+      "@context" "https://schema.org"
+      "@graph" (slice
+        (dict "@type" "WebSite" "name" "Eraser" "url" .Site.BaseURL "description" $desc "publisher" $org)
+        (dict "@type" "SoftwareApplication" "name" "Eraser"
+              "applicationCategory" "SecurityApplication"
+              "operatingSystem" "macOS, Linux, Windows"
+              "url" .Site.BaseURL
+              "description" $desc
+              "isAccessibleForFree" true
+              "offers" (dict "@type" "Offer" "price" "0" "priceCurrency" "USD")
+              "author" $org))
+  -}}
+{{- else if and .IsPage (eq .Section "guides") -}}
+  {{- $ld = dict
+      "@context" "https://schema.org"
+      "@type" "TechArticle"
+      "headline" .Title
+      "description" $desc
+      "url" .Permalink
+      "inLanguage" "en"
+      "author" $org
+      "publisher" $org
+  -}}
+{{- else -}}
+  {{- $ld = dict
+      "@context" "https://schema.org"
+      "@type" "WebPage"
+      "name" .Title
+      "description" $desc
+      "url" .Permalink
+      "isPartOf" (dict "@type" "WebSite" "name" "Eraser" "url" .Site.BaseURL)
+  -}}
+{{- end -}}
+<script type="application/ld+json">{{ $ld | jsonify | safeJS }}</script>

--- a/site/layouts/robots.txt
+++ b/site/layouts/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow:
+
+Sitemap: {{ "sitemap.xml" | absURL }}


### PR DESCRIPTION
## What

Fix the eraser docs site (eraser.drumandbytes.dev) not being indexed.

- **`site/layouts/robots.txt`** — Hugo already generates `/sitemap.xml` on every build, but the built-in `robots.txt` is a bare `User-agent: *` with no `Sitemap:` line. This template adds it.
- **`site/layouts/partials/head-seo.html`** — adds, wired into `baseof.html`:
  - Open Graph (`og:type` per page kind, title, description, url, site_name)
  - Twitter `summary` card
  - JSON-LD: `WebSite` + `SoftwareApplication` on the home page, `TechArticle` on `/guides/*`, `WebPage` elsewhere — shared `Organization` publisher ("Drum and Bytes").

No `og:image` — there's no card asset yet; `summary` renders fine without one.

## Verified

`hugo --minify` build clean (67 pages). `robots.txt` emits the `Sitemap:` line; `/sitemap.xml` has 65 same-host URLs; JSON-LD parses on home / guide / broker / section pages.

## Follow-up (not in this PR)

Register a `drumandbytes.dev` **domain property** in Google Search Console (apex `google-site-verification` TXT already exists) and submit `https://eraser.drumandbytes.dev/sitemap.xml`.