### PR TITLE
docs: surface quickstart above the fork note; price framing in hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,6 @@ You know those sites like Spokeo, BeenVerified, and Whitepages that have your ho
 
 ---
 
-## About This Fork
-
-This is a maintained fork of [digisamroc/eraser](https://github.com/digisamroc/eraser), which has been inactive since early 2026. It includes bug fixes, performance cleanups, and GDPR/EU-specific customizations on top of the original CCPA-focused tool.
-
-If you're an EU resident exercising GDPR rights rather than a US CCPA use case, read [EU-NOTES.md](EU-NOTES.md) first — it covers which template to pick, safe send-volume behavior, and what to do if a broker ignores your request.
-
----
-
 ## The Easy Way (Web Interface)
 
 If you're not comfortable with command-line tools, Eraser has a visual interface that runs in your web browser.
@@ -314,6 +306,14 @@ Yes, with caveats:
 | Incogni | $77/year | 180+ | No |
 | DeleteMe | $129/year | 750+ | No |
 | Privacy Duck | $500+/year | 500+ | No |
+
+---
+
+## About This Fork
+
+This is a maintained fork of [digisamroc/eraser](https://github.com/digisamroc/eraser), which has been inactive since early 2026. It includes bug fixes, performance cleanups, and GDPR/EU-specific customizations on top of the original CCPA-focused tool.
+
+If you're an EU resident exercising GDPR rights rather than a US CCPA use case, read [EU-NOTES.md](EU-NOTES.md) first — it covers which template to pick, safe send-volume behavior, and what to do if a broker ignores your request.
 
 ---
 

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -4,7 +4,8 @@
   <p>Eraser sends data removal requests to 700+ data brokers on your behalf — the
   companies like Spokeo, BeenVerified and Whitepages that publish your address,
   phone number and relatives. Open source, free, and it runs on your own machine:
-  requests go out from <em>your</em> mailbox, so no company ever holds your data.</p>
+  requests go out from <em>your</em> mailbox, so no company ever holds your data.
+  Incogni and DeleteMe charge $100+/year to do the same thing.</p>
   <p class="cta">
     <a class="btn" href="https://github.com/drumandbytes/eraser/releases">Download</a>
     <a class="btn ghost" href="{{ "/brokers" | relURL }}">Broker directory</a>


### PR DESCRIPTION
Phase 0 polish for promotion.

- **README**: moved `## About This Fork` down below `## How It Compares` — now the pitch is immediately followed by `## The Easy Way (Web Interface)` quickstart instead of the fork explainer.
- **Site hero** (`site/layouts/index.html`): added "Incogni and DeleteMe charge $100+/year to do the same thing." so the paid-alternative framing is above the fold, not just in the README.

`hugo --minify` builds clean.