### PR TITLE
chore(ci): pass dnb-robot via client-id org var

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/create-github-app-token@v2
         id: app_token
         with:
-          app-id: 4773076
+          client-id: ${{ vars.DNB_ROBOT_CLIENT_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: drumandbytes
           repositories: eraser,homebrew-tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/create-github-app-token@v2
         id: app_token
         with:
-          client-id: ${{ vars.DNB_ROBOT_CLIENT_ID }}
+          client-id: ${{ secrets.DNB_ROBOT_CLIENT_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: drumandbytes
           repositories: eraser,homebrew-tap


### PR DESCRIPTION
`actions/create-github-app-token` deprecated `app-id` in favor of `client-id` (the warning on recent runs). Swaps `app-id: 4773076` → `client-id: ${{ vars.DNB_ROBOT_CLIENT_ID }}` (new org variable) so future auth changes are one edit.