### PR TITLE
chore(ci): auto-merge patch-level release-please PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,3 +19,6 @@ jobs:
     # which is the actual safety gate; a run with no open PR just no-ops.
     if: github.event.workflow_run.conclusion == 'success'
     uses: drumandbytes/reusable-actions/.github/workflows/auto-merge.yml@v1
+    with:
+      # release-please's own PR; patch bumps auto-merge, minor/major don't.
+      patch-only-authors: '["dnb-robot[bot]"]'


### PR DESCRIPTION
## Summary
Wire in `patch-only-authors: '["dnb-robot[bot]"]'` (drumandbytes/reusable-actions#14, released as v1.11.0): release-please's PR auto-merges when the manifest version bump is patch-level, and is left alone for a minor/major bump so a human decides when to ship those.

## Test plan
- [ ] Confirm a future patch-only release PR auto-merges
- [ ] Confirm a minor/major one doesn't