### PR TITLE
chore(brokers): mark alphonso and loopme device-id-only after replies

### DIFF
--- a/data/brokers.yaml
+++ b/data/brokers.yaml
@@ -528,9 +528,10 @@ brokers:
       name: Alphonso Inc.
       email: compliance@lgads.tv
       website: https://www.lgads.tv/
-      opt_out_url: https://alphonso.tv/privacy/ccpa/
+      opt_out_url: https://alphonso.tv/privacy/consumer/
       region: us
-      category: marketing
+      category: device-id-only
+      notes: 'Reply (2026-09-05) from compliance@lgads.tv: TV-based ACR data only - IP addresses and device identifiers, no name or email, so a profile-based request can''t be matched. Rights are exercised via the form at the opt_out_url, which needs your current IP address to compare against - not reachable via this tool.'
     - id: altair-data-resources
       name: Altair Data Resources, Inc.
       email: privacy@altairdata.com
@@ -2957,8 +2958,10 @@ brokers:
       name: LOOPME LTD
       email: legal@loopme.com
       website: https://www.loopme.com/
+      opt_out_url: https://legal.loopme.com/privacy-center/loopme-opt-out
       region: us
-      category: marketing
+      category: device-id-only
+      notes: 'Reply (2026-09-03, via the shared Chartboost/LoopMe support desk): interest-based ad tech only - no name/email, so an email request can''t be actioned. Opt out by entering your Device ID on the opt_out_url page - not reachable via this tool''s profile-based request.'
     - id: lotadata
       name: Lotadata, Inc.
       email: ""


### PR DESCRIPTION
## What

Two replies to the GDPR Article 17 erasure requests (sent 2026-08-20) came back as the same "we only hold device/IP identifiers, no name or email" deflection. Updating both broker records to match the repo's existing `device-id-only` convention.

| Broker | Reply | Change |
|---|---|---|
| **Alphonso Inc. / LG Ads** | 2026-09-05, `mohammed.khan@lgads.tv` — TV-based ACR data only (IP + device IDs), no name/email; rights exercised via `alphonso.tv/privacy/consumer/` which needs your current IP | `category: marketing` → `device-id-only`; `opt_out_url` moved off the stale `/privacy/ccpa/` page to `/privacy/consumer/`; dated `notes:` |
| **LoopMe Ltd** | 2026-09-03, via the shared Chartboost/LoopMe support desk — interest-based ad tech, no name/email; opt out by entering a Device ID at `legal.loopme.com/privacy-center/loopme-opt-out` | `category: marketing` → `device-id-only`; added `opt_out_url`; dated `notes:` |

`email:` kept on both entries — a human replied to each.

## Why

So `eraser export` / overdue tracking stops treating these as unanswered controllers past the 1-month deadline, and a future `eraser send` understands the email route is a dead end for them.

No code changes — the `device-id-only` category already exists and is handled (`docs/architecture.md`, the advertising-broker guide). `site/content/brokers/*.md` are generated + gitignored; `data/brokers.yaml` is the source of truth.

## Verification

- `go build ./cmd/eraser`, `go vet ./...`, `go test ./...` — all pass (`TestEmbeddedBrokerDataValid` guards brokers.yaml structure)