### PR TITLE
fix(ci): opt into app-token merge, so releases actually finish

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -22,3 +22,10 @@ jobs:
     with:
       # release-please's own PR; patch bumps auto-merge, minor/major don't.
       patch-only-authors: '["dnb-robot[bot]"]'
+      # GITHUB_TOKEN-authored merges don't trigger further workflow runs, which
+      # left a release-please release stuck (manifest/changelog bumped, no
+      # tag/release/images ever built) — see drumandbytes/reusable-actions#16.
+      # This merges with the dnb-robot app token instead, so the merge properly
+      # cascades into another Release Please run that actually finishes the release.
+      use-app-token-for-merge: true
+    secrets: inherit


### PR DESCRIPTION
GITHUB_TOKEN-authored merges are excluded from triggering further workflow runs. This left a real release-please release stuck: manifest and changelog bumped, but the merge never re-triggered release-please to cut the tag/release, so no images/artifacts were ever built.

This repo's auto-merge sets `patch-only-authors` for `dnb-robot[bot]`, so it has the same exposure. Opting into `use-app-token-for-merge` (added in drumandbytes/reusable-actions#16) merges with the dnb-robot app token instead, so the merge cascades into another Release Please run that actually finishes the release.