### PR TITLE
feat(site): add Cloudflare Web Analytics to the public site

### DIFF
--- a/site/content/privacy.md
+++ b/site/content/privacy.md
@@ -1,0 +1,66 @@
+---
+title: "Privacy"
+description: "What this website collects, and what the tool on your machine doesn't."
+---
+
+Two different things live under this name, and they have very different answers.
+
+## The tool
+
+Eraser runs on your own machine. Your profile, the brokers you've contacted, and
+every response you've received stay in a local database on that machine. Removal
+requests go straight from your mail account to the broker.
+
+Nothing is sent to us. There is no account, no sync, no telemetry, and no
+server of ours in the path. We could not tell you how many people use Eraser, or
+which brokers they've written to, because we never receive any of it.
+
+That isn't a promise about our intentions — it's a property of how the thing is
+built, and you can check it in the source.
+
+## This website
+
+The site is static pages hosted on GitHub Pages, with one third-party script:
+Cloudflare Web Analytics.
+
+It records aggregate page views — which pages get visited, roughly how many
+times, and referrers. It sets **no cookies**, uses no cross-site identifier, and
+builds no profile of you. There's no way for us to single you out in it, which
+is also why there's no cookie banner to click through.
+
+Two processors are involved in serving you this page:
+
+| Who | What they see | Why |
+| --- | --- | --- |
+| GitHub (Pages) | Your IP address, as any web server does | Serving the site |
+| Cloudflare | Your IP address, transiently, for the analytics beacon | Aggregate visitor counts |
+
+Cloudflare is not in front of this site — the DNS record is unproxied, so GitHub
+serves you directly. Cloudflare only receives the analytics beacon your browser
+sends.
+
+## Lawful basis
+
+Aggregate, cookieless analytics on a public site: legitimate interest,
+GDPR Article 6(1)(f). Knowing roughly how many people find the project is
+proportionate, and it can't identify anyone.
+
+## Your rights
+
+We hold no personal data about you from this website — nothing is stored beyond
+the aggregate counts and whatever the processors above keep in their own logs.
+So there's nothing of yours for us to export or delete.
+
+If you use the tool, the data is on your computer, under your control. Delete
+the database and it's gone.
+
+## Who is responsible
+
+`[PLACEHOLDER — set to the OÜ once registered; until then, the controller is
+Maris Popens, reachable at maris@popens.lv.]`
+
+You can also raise anything publicly as a
+[GitHub issue](https://github.com/drumandbytes/eraser/issues/new).
+
+If you're in the EU or EEA and think we've got this wrong, you can complain to
+your national data protection authority — see [Privacy authorities](/authorities/).

--- a/site/content/privacy.md
+++ b/site/content/privacy.md
@@ -56,8 +56,8 @@ the database and it's gone.
 
 ## Who is responsible
 
-`[PLACEHOLDER — set to the OÜ once registered; until then, the controller is
-Maris Popens, reachable at maris@popens.lv.]`
+Eraser is run by Maris Popens, in Estonia. Write to <maris@popens.lv> about
+anything on this page, including any of the rights above.
 
 You can also raise anything publicly as a
 [GitHub issue](https://github.com/drumandbytes/eraser/issues/new).

--- a/site/layouts/baseof.html
+++ b/site/layouts/baseof.html
@@ -30,6 +30,7 @@
   <a href="https://github.com/drumandbytes/eraser">Source</a> ·
   MIT licensed ·
   Not legal advice — you're responsible for what you send ·
+  <a href="/privacy/">Privacy</a> ·
   <a href="https://github.com/drumandbytes/eraser/issues/new">Something wrong or missing?</a>
 </footer>
 </body>

--- a/site/layouts/baseof.html
+++ b/site/layouts/baseof.html
@@ -11,6 +11,10 @@
 <link rel="canonical" href="{{ .Permalink }}">
 {{ partial "head-seo.html" . }}
 <link rel="stylesheet" href="{{ "css/site.css" | relURL }}">
+<!-- Public site only. Don't add this to internal/web/templates: that's the
+     self-hosted UI, and beaconing from a user's own machine to report their use
+     of an erasure tool is the thing this product exists to avoid. -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "ec3bf39cd9974827a1fa7060f5c7e785"}'></script>
 </head>
 <body>
 <header class="topbar">


### PR DESCRIPTION
The marketing site at `eraser.drumandbytes.dev` has no analytics.

Snippet rather than Cloudflare's auto-injection, because that hostname is grey-clouded (`proxied = false` — deliberately, for GitHub Pages cert provisioning), so edge injection isn't available. Cookieless, so no consent banner. Token is public by design.

Added once in `baseof.html`, so it covers every page.

**Not** added to `internal/web/templates/` — that's the self-hosted app UI, running on users' own machines. Beaconing from there would report people's private use of a data-erasure tool back to us, which is the thing this product helps them avoid. There's a comment at the insertion point saying so, since "finish the coverage" is an easy mistake for someone to make later.