### PR TITLE
fix(site): load the beacon as a module, not a deferred script

### DIFF
--- a/site/layouts/baseof.html
+++ b/site/layouts/baseof.html
@@ -14,7 +14,7 @@
 <!-- Public site only. Don't add this to internal/web/templates: that's the
      self-hosted UI, and beaconing from a user's own machine to report their use
      of an erasure tool is the thing this product exists to avoid. -->
-<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "ec3bf39cd9974827a1fa7060f5c7e785"}'></script>
+<script type="module" src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "ec3bf39cd9974827a1fa7060f5c7e785"}'></script>
 </head>
 <body>
 <header class="topbar">


### PR DESCRIPTION
This site has recorded **zero** page views since the beacon shipped. Same root cause as drumandbytes/Mystery-Game#45.

7-day data across the account splits perfectly on one attribute:

| Host | Beacon tag | Views |
|---|---|---|
| drumandbytes.com | injected `type='module'` | 39 |
| f1walk.drumandbytes.dev | injected `type='module'` | 16 |
| roadconditions.drumandbytes.ee | injected `type='module'` | 6 |
| road-conditions-ee.pages.dev | injected `type='module'` | 2 |
| **mystery.drumandbytes.dev** | **manual `defer`** | **0** |
| **eraser.drumandbytes.dev** | **manual `defer`** | **0** |

Cloudflare's [FAQ](https://developers.cloudflare.com/web-analytics/faq/): *"For customers using the manual embed approach, you will need to add `type="module"` to the `<script>` tag manually."* Edge injection adds it automatically, which is why every injected host records.

Injection can't help this site regardless — the DNS record is unproxied, so GitHub Pages serves it directly and Cloudflare never sees the HTML. The docs confirm automatic setup requires proxied traffic. So the manual embed is mandatory here, and has to be right.

Verified `type="module"` survives the Hugo build on both the home and privacy pages.