### PR TITLE
fix(site): drop the manual beacon, let the edge inject it

### DIFF
--- a/site/layouts/baseof.html
+++ b/site/layouts/baseof.html
@@ -11,10 +11,12 @@
 <link rel="canonical" href="{{ .Permalink }}">
 {{ partial "head-seo.html" . }}
 <link rel="stylesheet" href="{{ "css/site.css" | relURL }}">
-<!-- Public site only. Don't add this to internal/web/templates: that's the
-     self-hosted UI, and beaconing from a user's own machine to report their use
-     of an erasure tool is the thing this product exists to avoid. -->
-<script type="module" src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "ec3bf39cd9974827a1fa7060f5c7e785"}'></script>
+<!-- No analytics beacon here on purpose. Cloudflare injects one at the edge for
+     this host, and a hand-embedded tag would sit above it and win -- only the
+     first beacon on a page is used -- which is exactly why this site recorded
+     nothing while it had one. Never add one to internal/web/templates either:
+     that's the self-hosted UI, and beaconing from a user's own machine to
+     report their use of an erasure tool is what this product exists to avoid. -->
 </head>
 <body>
 <header class="topbar">


### PR DESCRIPTION
> **Merge after** drumandbytes/dnb-cloudflare-tf#20 is applied. That PR proxies this hostname so Cloudflare can inject a beacon at all; without it this leaves the site with none.

This site has recorded **zero** page views for as long as it has carried a hand-embedded beacon.

Manual tags post cross-origin to `cloudflareinsights.com/cdn-cgi/rum` — a request that failed silently in Chrome, Safari, and Brave. Injected tags post **same-origin** to `<host>/cdn-cgi/rum`, which works. Removing the manual tag also matters on its own terms: only the **first** beacon in DOM order is used per page, so a hand-written tag sitting above an injected one shadows it. That was the exact bug on `mystery.drumandbytes.dev`, which started recording the moment its manual tag was deleted.

The `type=module` fix in #38 was a genuine improvement but not the cause — the cross-origin POST was.

The comment stays, reworded: nothing may add a beacon to `internal/web/templates`. That's the self-hosted UI, and beaconing from a user's own machine to report their use of an erasure tool is precisely what this product exists to avoid.

Verified the Hugo build emits no `cloudflareinsights` reference on either the home or privacy page.