### PR TITLE
fix(audit): stop reporting blocked sites as dead brokers

### DIFF
--- a/cmd/eraser/cmd_audit.go
+++ b/cmd/eraser/cmd_audit.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -32,6 +33,13 @@ type auditChecker struct {
 	httpHead   func(url string) (*http.Response, error)
 }
 
+// A browser User-Agent, because plenty of brokers' WAFs reject Go's default
+// "Go-http-client/2.0" outright. This is about not looking like a broken bot,
+// not about defeating bot protection -- anything that still blocks us is
+// reported as "unknown", never as evidence the broker is gone.
+const auditUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+	"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36"
+
 func newAuditChecker(timeout time.Duration) *auditChecker {
 	client := &http.Client{
 		Timeout: timeout,
@@ -46,7 +54,25 @@ func newAuditChecker(timeout time.Duration) *auditChecker {
 		lookupMX:   net.LookupMX,
 		lookupHost: net.LookupHost,
 		httpHead: func(url string) (*http.Response, error) {
-			return client.Head(url)
+			// HEAD first (cheap), then GET on failure: a fair number of sites
+			// never implement HEAD and drop the connection rather than answering
+			// 405, which is indistinguishable from being dead.
+			for _, method := range []string{http.MethodHead, http.MethodGet} {
+				req, err := http.NewRequest(method, url, nil)
+				if err != nil {
+					return nil, err
+				}
+				req.Header.Set("User-Agent", auditUserAgent)
+				req.Header.Set("Accept", "text/html,application/xhtml+xml,*/*;q=0.8")
+				resp, err := client.Do(req)
+				if err == nil {
+					return resp, nil
+				}
+				if method == http.MethodGet {
+					return nil, err
+				}
+			}
+			return nil, nil // unreachable: the loop always returns
 		},
 	}
 }
@@ -121,14 +147,19 @@ func runAuditBrokers(region, category string, timeout time.Duration, failOnDead 
 	printAuditResults(results)
 
 	if failOnDead {
+		// email-dead only. A dead mail domain is checkable from anywhere and means
+		// the removal request has nowhere to go, which is the thing that actually
+		// breaks the product. website-dead is still printed above, but it cannot
+		// distinguish "gone" from "blocks CI", so failing on it makes a scheduled
+		// job that always fails -- an alarm nobody reads.
 		dead := 0
 		for _, r := range results {
-			if r.verdict == verdictEmailDead || r.verdict == verdictWebsiteDead {
+			if r.verdict == verdictEmailDead {
 				dead++
 			}
 		}
 		if dead > 0 {
-			return fmt.Errorf("%d broker(s) have a dead email domain or unreachable website - see the list above", dead)
+			return fmt.Errorf("%d broker(s) have a dead email domain - see the list above", dead)
 		}
 	}
 
@@ -199,6 +230,16 @@ func checkEmailAlive(email string, checker *auditChecker) bool {
 func checkWebsiteVerdict(website string, checker *auditChecker) auditVerdict {
 	resp, err := checker.httpHead(website)
 	if err != nil {
+		// A transport error only means "gone" if the name no longer resolves.
+		// If DNS still answers, we are far more likely to be blocked than to be
+		// looking at a dead broker -- these checks run from CI, and data brokers
+		// routinely refuse datacenter ranges. Calling that dead produced 73 false
+		// positives against 1 real one on the first scheduled run.
+		if host := hostOf(website); host != "" {
+			if addrs, lookupErr := checker.lookupHost(host); lookupErr == nil && len(addrs) > 0 {
+				return verdictUnknown
+			}
+		}
 		return verdictWebsiteDead
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -209,6 +250,15 @@ func checkWebsiteVerdict(website string, checker *auditChecker) auditVerdict {
 	// Many privacy/opt-out pages block bot/headless requests (403, etc.) -
 	// that's not evidence the broker is gone, just an inconclusive check.
 	return verdictUnknown
+}
+
+// hostOf extracts the hostname from a broker's website URL, empty if unparseable.
+func hostOf(website string) string {
+	u, err := url.Parse(website)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
 }
 
 func printAuditResults(results []auditResult) {

--- a/cmd/eraser/cmd_audit.go
+++ b/cmd/eraser/cmd_audit.go
@@ -217,6 +217,14 @@ func checkEmailAlive(email string, checker *auditChecker) bool {
 	domain := email[at+1:]
 
 	if mxs, err := checker.lookupMX(domain); err == nil && len(mxs) > 0 {
+		// A null MX (RFC 7505) is a single "." record, and it is the domain
+		// explicitly stating that it accepts no mail at all. Counting it as a
+		// live contact is worse than finding no MX: this is a definitive answer,
+		// not a missing one. No broker publishes one today, so this guards a
+		// silent future false positive rather than fixing a current miscount.
+		if len(mxs) == 1 && (mxs[0].Host == "." || mxs[0].Host == "") {
+			return false
+		}
 		return true
 	}
 	// Some domains route mail without a dedicated MX record (implicit MX

--- a/cmd/eraser/cmd_audit_test.go
+++ b/cmd/eraser/cmd_audit_test.go
@@ -67,6 +67,19 @@ func TestAuditOneWebsiteDeadOnConnectionError(t *testing.T) {
 	}
 }
 
+// The distinction that keeps the scheduled audit honest: a connection failure is
+// only evidence of death when the hostname has stopped resolving. If DNS still
+// answers, we are far likelier to have been refused for running in a datacenter.
+// The first scheduled run called 73 brokers dead this way against 1 real one.
+func TestAuditOneWebsiteUnknownWhenHostStillResolves(t *testing.T) {
+	b := broker.Broker{ID: "veromi", Email: "privacy@veromi.net", Website: "https://www.veromi.net"}
+	checker := stubChecker(1, 1, 0, errConnRefused)
+
+	if got := auditOne(b, checker); got != verdictUnknown {
+		t.Errorf("auditOne() = %q, want %q (a resolving host that refuses us is inconclusive, not dead)", got, verdictUnknown)
+	}
+}
+
 func TestAuditOneWebsiteUnknownOnNon2xxStatus(t *testing.T) {
 	b := broker.Broker{ID: "spokeo", Email: "privacy@spokeo.com", Website: "https://spokeo.com"}
 	checker := stubChecker(1, 0, 403, nil)

--- a/cmd/eraser/cmd_audit_test.go
+++ b/cmd/eraser/cmd_audit_test.go
@@ -71,6 +71,20 @@ func TestAuditOneWebsiteDeadOnConnectionError(t *testing.T) {
 // only evidence of death when the hostname has stopped resolving. If DNS still
 // answers, we are far likelier to have been refused for running in a datacenter.
 // The first scheduled run called 73 brokers dead this way against 1 real one.
+// RFC 7505: a lone "." MX means the domain accepts no mail. Go surfaces it as a
+// normal record, so a naive len(mxs) > 0 reads it as a working contact.
+func TestAuditOneEmailDeadOnNullMX(t *testing.T) {
+	b := broker.Broker{ID: "nomail", Email: "privacy@nomail.example", Website: "https://nomail.example"}
+	checker := stubChecker(1, 0, 200, nil)
+	checker.lookupMX = func(domain string) ([]*net.MX, error) {
+		return []*net.MX{{Host: ".", Pref: 0}}, nil
+	}
+
+	if got := auditOne(b, checker); got != verdictEmailDead {
+		t.Errorf("auditOne() = %q, want %q (a null MX is an explicit refusal of mail)", got, verdictEmailDead)
+	}
+}
+
 func TestAuditOneWebsiteUnknownWhenHostStillResolves(t *testing.T) {
 	b := broker.Broker{ID: "veromi", Email: "privacy@veromi.net", Website: "https://www.veromi.net"}
 	checker := stubChecker(1, 1, 0, errConnRefused)


### PR DESCRIPTION
The first scheduled Broker audit failed with **74 dead brokers**. Most of that was wrong.

## What the numbers hid

```
✗ email-dead: 1      ← checkable from anywhere, reliable
✗ website-dead: 73   ← transport failures, i.e. what being blocked looks like
```

Spot-checking the 73: `peekyou.com`, `venpath.net` and `whoodle.com` are genuinely **NXDOMAIN**, but `veromi.net` answers **200** from a residential IP while CI called it gone. Data brokers routinely refuse datacenter ranges — and the checker was sending Go's default `Go-http-client/2.0` with a bare `HEAD`, which plenty of sites reject on sight.

## Three changes

None of them try to defeat bot protection. Anything that still refuses us is reported as `unknown`, never as evidence a broker is gone:

1. Send a browser `User-Agent` and `Accept` header
2. Fall back to `GET` when `HEAD` fails — some sites never implement it and drop the connection rather than answering 405, which is indistinguishable from death
3. **Only call a site dead when its hostname stops resolving.** A transport error against a name that still answers DNS is inconclusive

## Measured against the live database

| | Before | After |
|---|---|---|
| alive | 546 | **621** |
| website-dead | 73 | **32** |
| unknown | 142 | 108 |
| email-dead | 1 | 1 |

75 brokers recovered from misclassification.

## `--fail-on-dead` now trips on email-dead only

A dead mail domain means a removal request has nowhere to go — the thing that actually breaks the product, and verifiable from any network. `website-dead` still prints, but it can't tell "gone" from "blocks CI", and failing on it guarantees a permanently red scheduled job, which is an alarm nobody reads. This mirrors what `auditOne`'s own comment already argued.

## The one real finding

`cross-pixel-media` → `stephanie.mccabe@knowertech.ca`. **`knowertech.ca` is NXDOMAIN.** The broker's own notes record that Cross Pixel forwarded them to Knower Tech as successor (reply 2026-08-20) — and that successor's domain no longer exists.

Left for a human deliberately: I'm not guessing a contact address into a privacy tool, because a wrong one sends users' removal requests to the wrong party. Its opt-out URL (`privacy.crsspxl.com/optout`) still returns **200**, so that may be the route.

CI stays red until that broker is resolved — which is now a real signal rather than noise.