### PR TITLE
fix(brokers): drop Cross Pixel Media's undeliverable contact

### DIFF
--- a/data/brokers.yaml
+++ b/data/brokers.yaml
@@ -1291,12 +1291,11 @@ brokers:
       category: marketing
     - id: cross-pixel-media
       name: Cross Pixel Media, Inc.
-      email: stephanie.mccabe@knowertech.ca
       website: https://www.crosspixel.net/
       opt_out_url: https://privacy.crsspxl.com/optout
       region: us
       category: marketing
-      notes: apearlstein@crosspixel.net replied that Alan has left Cross Pixel Media; forwarded us to Stephanie McCabe, President of Knower Tech (successor company) (reply received 2026-08-20).
+      notes: 'No email on file: apearlstein@crosspixel.net replied that Alan has left Cross Pixel Media and forwarded us to Stephanie McCabe, President of Knower Tech, the successor company (reply received 2026-08-20). That forwarding address, stephanie.mccabe@knowertech.ca, was removed on 2026-09-07 because knowertech.ca no longer resolves at all (NXDOMAIN, no MX) -- mail to it cannot be delivered, so sending there made a request look sent when it never left. Use the opt-out form instead; it was still answering 200 when this was checked.'
     - id: crosswalk-technologies
       name: Crosswalk Technologies Inc
       email: privacy@crosswalknyc.com


### PR DESCRIPTION
Resolves the finding that kept the scheduled Broker audit red.

## The problem

`knowertech.ca` no longer resolves — **NXDOMAIN, no MX**. Mail to `stephanie.mccabe@knowertech.ca` cannot be delivered.

That made it worse than having no address at all: `eraser send` rendered a message and attempted delivery, so a user would believe their removal request went out when it never left. A silent failure in a tool whose entire job is getting those requests delivered.

## Why removing the field is the supported path

`cmd_send.go` already handles this, and its comment names this exact case:

> Brokers with no email on file (**confirmed defunct**, or "use the web form instead" cases documented in their notes) have nothing to send to — skip rather than let the SMTP layer choke on an empty recipient

With the field gone, users are pointed at the opt-out form instead:

```
⏭️  No email on file - use the opt-out form instead: https://privacy.crsspxl.com/optout
```

The web UI does the same, marking it "needs manual follow-up". That form still returned **200** when checked.

## History kept

The forwarding chain stays in `notes` — including *why* the address was removed and *when* it died — so nobody re-adds it from the same 2026-08-20 reply thread.

## Verified

```
validate-brokers  → ✓ embedded broker list is valid (763 brokers)
audit-brokers     → alive 623, email-dead 0, website-dead 32, unknown 107  (exit 0)
go test ./...     → pass
```

The audit was already reporting identical numbers in CI and locally after #43, so this should go green on the next scheduled run.

## Not done

I didn't hunt for a replacement address. Guessing a contact into a privacy tool risks routing someone's removal request to the wrong party; if Knower Tech turns out to have a live domain, adding it is a deliberate decision with evidence behind it.