### PR TITLE
feat(brokers): restore a verified contact for Cross Pixel Media

### DIFF
--- a/data/brokers.yaml
+++ b/data/brokers.yaml
@@ -1291,11 +1291,12 @@ brokers:
       category: marketing
     - id: cross-pixel-media
       name: Cross Pixel Media, Inc.
+      email: privacy@crosspixel.net
       website: https://www.crosspixel.net/
       opt_out_url: https://privacy.crsspxl.com/optout
       region: us
       category: marketing
-      notes: 'No email on file: apearlstein@crosspixel.net replied that Alan has left Cross Pixel Media and forwarded us to Stephanie McCabe, President of Knower Tech, the successor company (reply received 2026-08-20). That forwarding address, stephanie.mccabe@knowertech.ca, was removed on 2026-09-07 because knowertech.ca no longer resolves at all (NXDOMAIN, no MX) -- mail to it cannot be delivered, so sending there made a request look sent when it never left. Use the opt-out form instead; it was still answering 200 when this was checked.'
+      notes: 'Use the role address, not a person. apearlstein@crosspixel.net replied that Alan had left and forwarded us to Stephanie McCabe at Knower Tech, the successor company (2026-08-20); that forwarding address was stephanie.mccabe@knowertech.ca, and knowertech.ca is now NXDOMAIN with no MX, so it was dropped on 2026-09-07. privacy@crosspixel.net replaced it: Cross Pixel''s own privacy policy (effective 2025-12-08) names it for exercising data rights -- "You can exercise these rights at any time by visiting our Privacy Portal or by emailing us at privacy@crosspixel.net" -- and crosspixel.net has live Google Workspace MX. A departing employee does not invalidate a published role address. Knower Tech is real (knowertech.com lists McCabe as President and references Cross Pixel) but publishes no contact address at all; its contact and privacy pages still carry unfilled theme placeholders, so there was nothing verifiable to use there.'
     - id: crosswalk-technologies
       name: Crosswalk Technologies Inc
       email: privacy@crosswalknyc.com


### PR DESCRIPTION
Replaces the address removed in #45 with one taken from the controller's own privacy policy.

## The address

`privacy@crosspixel.net` — from Cross Pixel's privacy policy, **effective 2025-12-08**:

> You can exercise these rights at any time by visiting our Privacy Portal or by emailing us at **privacy@crosspixel.net**

Verified on the three counts that matter:

| | |
|---|---|
| **Published** | by the controller, on its own current privacy policy |
| **Purpose-designated** | named specifically for exercising data rights |
| **Deliverable** | `crosspixel.net` has live Google Workspace MX |

That distinction matters more here than in most projects: a removal request carries the user's *own* personal data, so a guessed address discloses their PII to whoever happens to hold that mailbox.

## Why not Knower Tech

The 2026-08-20 reply forwarded us to Stephanie McCabe at Knower Tech. Following that up:

- Knower Tech is real — `knowertech.com` lists **"Stephanie McCabe, President"** and references Cross Pixel
- `knowertech.ca` from the original note is **NXDOMAIN, no MX** — a wrong or lapsed domain
- `knowertech.com` **publishes no contact address at all**: its contact and privacy pages still carry unfilled theme placeholders (`person@companycorp.com`, `privacy@knowcompany.com`) pointing at unrelated parked domains

So `stephanie.mccabe@knowertech.com` was the obvious guess, and it stays a guess. Meanwhile the forwarding reply was about **Alan Pearlstein leaving** — a departing employee doesn't retire a published role address.

## Verified

```
validate-brokers → ✓ 763 brokers valid
audit-brokers    → alive 621, email-dead 0  (exit 0)
go test ./...    → pass
```