### PR TITLE
chore: pin go and hugo with mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,10 @@
+[tools]
+# Pinned to match CI so a local build can't pass against a different toolchain.
+#
+# go tracks the go directive in go.mod; bump both together or `go build` starts
+# rejecting the module.
+go = "1.26"
+# hugo builds site/. Pinned exactly rather than "latest" because Hugo ships
+# breaking template changes in minor releases, and a local build that silently
+# used a newer one would produce different HTML than .github/workflows/deploy.yaml.
+hugo = "0.165.0"


### PR DESCRIPTION
CI pins `go 1.26` and `hugo 0.165.0`. Nothing pinned them locally, so a local build could pass against whatever happened to be on `PATH` — the same gap Mystery-Game had before drumandbytes/Mystery-Game#52.

`hugo` is pinned **exactly**, not to a range: it ships breaking template changes in minor releases, so a newer local Hugo would quietly produce different HTML than `deploy.yaml` does. `go` tracks the `go` directive in `go.mod` — bump both together or `go build` starts rejecting the module.

Verified after `mise install`:

```
go version go1.26.8 darwin/arm64
hugo v0.165.0
hugo --source site   → builds
go build ./...       → passes
```

Setup is `mise install` in the repo.