### PR TITLE
Mark goodhire as dead end (Checkr FCRA exemption)

### DIFF
--- a/data/brokers.yaml
+++ b/data/brokers.yaml
@@ -217,10 +217,11 @@ brokers:
       notes: 'privacy@checkr.com bounced; hello@checkr.com is the address Checkr''s own privacy policy recommends. Updated 2026-08-20.'
     - id: goodhire
       name: GoodHire
-      email: privacy@goodhire.com
+      email: ''
       website: https://www.goodhire.com
       region: us
       category: background-check
+      notes: 'privacy@goodhire.com is dead (2026-09-08): GoodHire discontinued that inbox and now routes privacy support to Checkr (help.checkr.com), which owns and operates GoodHire''s background-check product. Checkr states it is not required to delete personal information as a consumer reporting agency under the FCRA, and cites further exemptions under the GLBA and DPPA - so this is a dead end for an erasure request regardless of address. See the separate `checkr` entry.'
     - id: sterling
       name: Sterling
       email: privacy@sterlingcheck.com


### PR DESCRIPTION
## Summary

- `privacy@goodhire.com` is dead — GoodHire discontinued that inbox and now routes privacy support through Checkr (help.checkr.com), which owns and operates the GoodHire background-check product.
- Checkr explicitly states it isn't required to delete personal information as a consumer reporting agency under the FCRA, citing further exemptions under the GLBA and DPPA — so no reachable address makes this anything but a dead end for an erasure request.
- Cleared the dead email (`email: ''`, matching the `send`-skips-unreachable-brokers convention) and added a `notes` entry explaining why, following the existing `saferent-solutions` precedent for CRA exemptions.

Fixes #50

## Test plan

- [x] `go build -o /tmp/eraser-build ./cmd/eraser`
- [x] `go test ./internal/broker/...` (broker structure validation against the embedded copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YModz34xotvPi2wm8cG9ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01YModz34xotvPi2wm8cG9ry)_