### PR TITLE
docs: quote 750+ brokers rather than 700+

### DIFF
--- a/EU-NOTES.md
+++ b/EU-NOTES.md
@@ -4,7 +4,7 @@ This fork of [eraser](https://github.com/digisamroc/eraser) is set up for an EU/
 
 ## What changed
 
-`data/brokers.yaml` originally shipped 764 brokers, 751 of them US-region. That's kept as-is (US-owned platforms, ad-tech, and breach-sourced people-search sites do end up holding EU residents' data too), plus EU/UK entries with direct opt-out emails have been added as they were found. The exact count moves around over time - EU/UK additions push it up, campaign-response reviews that find duplicate/dead entries push it back down (see auditing.md) - which is why the docs quote "700+" rather than a specific number. Run `grep -c '^    - id:' data/brokers.yaml` for the current true count:
+`data/brokers.yaml` originally shipped 764 brokers, 751 of them US-region. That's kept as-is (US-owned platforms, ad-tech, and breach-sourced people-search sites do end up holding EU residents' data too), plus EU/UK entries with direct opt-out emails have been added as they were found. The exact count moves around over time - EU/UK additions push it up, campaign-response reviews that find duplicate/dead entries push it back down (see auditing.md) - which is why the docs quote a round floor rather than a specific number. That floor moved from "700+" to "750+" on 2026-09-08, when the list stood at 763 -- note that leaves far less headroom than "700+" did, so a dedup pass that drops it below 750 makes the claim false rather than merely conservative. Run `grep -c '^    - id:' data/brokers.yaml` for the current true count:
 
 - `192-com` (192.com, UK)
 - `creditreform-de` (Creditreform, Germany)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eraser
 
-Take back your privacy. Eraser sends data removal requests to 700+ data brokers on your behalf—for free.
+Take back your privacy. Eraser sends data removal requests to 750+ data brokers on your behalf—for free.
 
 📖 **[eraser.drumandbytes.dev](https://eraser.drumandbytes.dev)** — broker directory, opt-out guides, and the list of EU/EEA data protection authorities.
 
@@ -8,7 +8,7 @@ You know those sites like Spokeo, BeenVerified, and Whitepages that have your ho
 
 ### What to Expect
 
-**The good:** Eraser automatically sends removal request emails to 700+ data brokers. Many brokers process these requests automatically—you send the email, they remove your data, done.
+**The good:** Eraser automatically sends removal request emails to 750+ data brokers. Many brokers process these requests automatically—you send the email, they remove your data, done.
 
 **The reality:** Some brokers require additional steps. They might send you a confirmation link to click, ask you to fill out a form on their website, or request identity verification. Eraser tracks these responses and shows you exactly what needs manual attention.
 
@@ -90,7 +90,7 @@ The wizard walks you through entering your personal information (the data broker
 **Step 4: Send Removal Requests**
 
 From the dashboard, you can:
-- Browse the list of 700+ data brokers
+- Browse the list of 750+ data brokers
 - Send requests one at a time or in bulk
 - Track which requests have been sent and their status
 - Exclude a broker from sends with one click (and bring it back later) - useful for a broker you'd rather skip, e.g. one that demands ID verification
@@ -162,7 +162,7 @@ On Windows, build it as `eraser.exe` instead (`go build -o eraser.exe ./cmd/eras
 | `eraser send --dry-run` | Preview without sending |
 | `eraser send --ignore-daily-limit` | Send everything in one run, ignoring the daily cap |
 | `eraser send --resend` | Force re-send even to brokers within the cooldown window |
-| `eraser list-brokers` | Show all 700+ brokers |
+| `eraser list-brokers` | Show all 750+ brokers |
 | `eraser status` | View history and stats |
 | `eraser status --limit 50` | Show more history |
 | `eraser add-broker` | Add a custom broker interactively |
@@ -346,7 +346,7 @@ eraser/
 │   │   └── templates/            # gdpr.tmpl, ccpa.tmpl, generic.tmpl
 │   └── web/                     # Web UI - server.go has core setup, handlers_*.go files
 │                                 # hold the actual page/API handlers by resource
-├── data/brokers.yaml           # 700+ broker database
+├── data/brokers.yaml           # 750+ broker database
 ├── config.example.yaml         # Example configuration
 └── EU-NOTES.md                 # GDPR/EU-specific setup and customization notes
 ```

--- a/cmd/eraser/cmd_audit.go
+++ b/cmd/eraser/cmd_audit.go
@@ -167,7 +167,7 @@ func runAuditBrokers(region, category string, timeout time.Duration, failOnDead 
 }
 
 // auditConcurrently runs auditOne for each broker with a bounded worker
-// pool - checking 700+ brokers one at a time over DNS/HTTP would be slow.
+// pool - checking 750+ brokers one at a time over DNS/HTTP would be slow.
 func auditConcurrently(targets []broker.Broker, checker *auditChecker, workers int) []auditResult {
 	results := make([]auditResult, len(targets))
 	sem := make(chan struct{}, workers)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,7 @@ eraser/
 │       │                        # (setup wizard), handlers_profile.go (profile switching)
 │       ├── job.go               # Job/JobManager - background send-job state, mutex-protected
 │       └── session.go           # Setup-wizard session store
-├── data/brokers.yaml            # 700+ data broker database (embedded via data/embed.go)
+├── data/brokers.yaml            # 750+ data broker database (embedded via data/embed.go)
 ├── scripts/import-registries/   # helper: grow brokers.yaml from state registry CSVs
 ├── docs/                        # Granular reference docs (this directory)
 └── EU-NOTES.md                  # GDPR/EU-specific setup and customization notes

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -596,7 +596,7 @@
 <body>
     <!-- Navigation: a flush top bar (not a floating pill) so pages get the
          full viewport width - matters most on data-dense pages like the
-         777-broker list. -->
+         750+-broker list. -->
     <nav class="site-nav">
         <div class="max-w-6xl mx-auto px-4 site-nav-inner">
             <!-- Logo -->

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -1,4 +1,4 @@
 ---
 title: "Eraser"
-description: "Send data removal requests to 700+ data brokers. Open source, local-first, free."
+description: "Send data removal requests to 750+ data brokers. Open source, local-first, free."
 ---

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <section class="hero">
   <h1>Take back your privacy</h1>
-  <p>Eraser sends data removal requests to 700+ data brokers on your behalf — the
+  <p>Eraser sends data removal requests to 750+ data brokers on your behalf — the
   companies like Spokeo, BeenVerified and Whitepages that publish your address,
   phone number and relatives. Open source, free, and it runs on your own machine:
   requests go out from <em>your</em> mailbox, so no company ever holds your data.


### PR DESCRIPTION
The list stands at **763** (`grep -c '^    - id:' data/brokers.yaml`), so "700+" was understating it by more than sixty.

Raised across the README (×5), the site copy, `docs/architecture.md`, and the audit helper's comment. `internal/web/templates/setup/complete.html` already said 750+.

## Deliberately left alone

| | why |
|---|---|
| `docs/auditing.md` "~500+ brokers" | that's the **California CPPA registry**, a source we pull from — not our list |
| `EU-NOTES.md` "originally shipped 764" | historical statement about the first import, not a current claim |

## Headroom is now much tighter

`EU-NOTES.md` documents *why* the docs quote a round floor: the count moves as EU/UK entries are added and dedup passes remove dead ones. That note now records the move and its consequence —

**750+ against 763 leaves 13 of headroom, where 700+ had 63.**

A dedup pass dropping the list below 750 makes the claim *false* rather than merely conservative. Worth knowing before the next campaign-response review.

## Also

Fixes the only `777` in the repo — a stale comment in `layout.html` describing the broker-list page.

The **GitHub repo description** also said "777+ data brokers"; corrected to 750+ directly, since it isn't in version control.

`go build ./...` and `go test ./...` both clean.