### PR TITLE
docs: broker-reply handling workflow + CLAUDE.md expansion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,3 +24,15 @@ go test ./...
 ```
 
 See [docs/commands.md](docs/commands.md) for the full CLI reference.
+
+## Conventions
+
+- **Commits**: Conventional Commits with a scope - `feat(brokers):`, `fix(site):`, `fix(audit):`, `chore(ci):`, `docs:`. [release-please](.release-please-manifest.json) reads them to bump the version and write `CHANGELOG.md`; an unscoped or non-conventional message just won't appear in the changelog. No `Co-Authored-By` / attribution trailers.
+- **Branches & PRs**: work on a branch, open a PR, squash-merge. `main` stays releasable; patch-level release PRs auto-merge.
+- **Go code**: idioms, package layout, and known quirks are in [docs/code-patterns.md](docs/code-patterns.md) - read the "Known quirks" section before touching `send`, the reply classifier, history scoping, or the web UI's CSS.
+
+## Recurring work
+
+- **Acting on broker email replies** - the frequent one: classify the reply, make the matching `data/brokers.yaml` edit. [docs/broker-replies.md](docs/broker-replies.md).
+- **Keeping `data/brokers.yaml` honest** - liveness audit, dedup, growing the list from registries, and the "750+" count floor: [docs/auditing.md](docs/auditing.md).
+- **Re-sending** - brokers re-list you continuously. `./eraser send` is safe to re-run: it resumes where it left off (25-day per-broker cooldown, `daily_send_limit` cap). EU cadence and hand-sending are in [EU-NOTES.md](EU-NOTES.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ This file is intentionally slim. Read the doc(s) relevant to what you're touchin
 
 - [docs/architecture.md](docs/architecture.md) - tech stack, project structure, broker/template/send-flow concepts
 - [docs/commands.md](docs/commands.md) - full CLI command reference, config.yaml schema
+- [docs/broker-replies.md](docs/broker-replies.md) - reading data-broker email replies and turning each response type into the right brokers.yaml edit
 - [docs/multi-profile.md](docs/multi-profile.md) - the `--profile`/`profiles:` feature: config model, history scoping, shared-inbox attribution, web UI switcher
 - [docs/code-patterns.md](docs/code-patterns.md) - conventions to follow, plus known quirks/gotchas worth reading before touching related code
 - [docs/auditing.md](docs/auditing.md) - how to re-run the dead-code/security sweep, and what's already been removed

--- a/data/brokers.yaml
+++ b/data/brokers.yaml
@@ -1298,13 +1298,6 @@ brokers:
       region: us
       category: marketing
       notes: 'Use the role address, not a person. apearlstein@crosspixel.net replied that Alan had left and forwarded us to Stephanie McCabe at Knower Tech, the successor company (2026-08-20); that forwarding address was stephanie.mccabe@knowertech.ca, and knowertech.ca is now NXDOMAIN with no MX, so it was dropped on 2026-09-07. privacy@crosspixel.net replaced it: Cross Pixel''s own privacy policy (effective 2025-12-08) names it for exercising data rights -- "You can exercise these rights at any time by visiting our Privacy Portal or by emailing us at privacy@crosspixel.net" -- and crosspixel.net has live Google Workspace MX. A departing employee does not invalidate a published role address. Knower Tech is real (knowertech.com lists McCabe as President and references Cross Pixel) but publishes no contact address at all; its contact and privacy pages still carry unfilled theme placeholders, so there was nothing verifiable to use there.'
-    - id: crosswalk-technologies
-      name: Crosswalk Technologies Inc
-      email: privacy@crosswalknyc.com
-      website: https://www.crosswalknyc.com/
-      opt_out_url: https://www.crosswalknyc.com/optout
-      region: us
-      category: marketing
     - id: crunchbase
       name: Crunchbase Inc
       email: privacy@crunchbase.com
@@ -5044,9 +5037,9 @@ brokers:
     - id: videoamp
       name: Videoamp, Inc.
       email: ""
-      notes: 'Consumer rights page requires a device/advertising identifier to locate and act on a request; no name/email-only path offered.'
+      notes: 'privacy@videoamp.com replied (2026-09-08) that they will not process any request not submitted via their web form (opt_out_url) or their toll-free number (844) 954-1754. Earlier finding still holds: the consumer-rights flow also wants a device/advertising identifier, with no name/email-only path.'
       website: https://www.videoamp.com/
-      opt_out_url: https://www.videoamp.com/consumer-rights-under-ccpa
+      opt_out_url: https://videoamp.com/your-privacy-choices/
       region: us
       category: device-id-only
     - id: virtual-marketing

--- a/docs/broker-replies.md
+++ b/docs/broker-replies.md
@@ -1,0 +1,47 @@
+# Handling Broker Replies
+
+What to do when a data broker answers a removal request. Most replies need no repo
+change; the ones that do are broker-level facts, recorded in `data/brokers.yaml`.
+
+## How replies reach you
+
+Replies land in the mailbox you sent from. `eraser monitor` is the automated path:
+it pulls broker-domain mail over IMAP, classifies each one
+(`internal/inbox/classifier.go`), and writes SQLite history + pipeline rows
+(`eraser pipeline` shows what still needs a human). Reading the inbox by hand is
+the same job without the database writes.
+
+Per-request status (sent, acknowledged, confirmed, overdue) lives in Gmail and the
+SQLite history - not in this repo. Only facts about the *broker itself* go in
+`data/brokers.yaml`. See [EU-NOTES.md](../EU-NOTES.md) for why there's no
+review-status file here.
+
+Once you've actioned a reply, move it out of the inbox (Trash is fine - it's
+reversible; nothing here empties the trash).
+
+## Response → action
+
+Classifications match `ResponseType` in `internal/inbox/classifier.go`.
+
+| Reply says | Type | Action |
+|---|---|---|
+| Deletion done / suppressed / "we no longer hold your data" | `success` | none - archive the mail |
+| "No record / no match for you" from a genuine broker | `rejected` | none - they're still a real broker, a future re-scrape may list you again |
+| "We are not a data broker" / "B2B only, not in scope" | `rejected` | remove the entry from `data/brokers.yaml`, then check the count floor (below) |
+| "We won't process this by email - use our web form / portal" | `form_required` | set `email: ""`, set/refresh `opt_out_url` to the form they name, add a dated `notes:` line |
+| Won't act without a government-ID document | - | set `category: requires-id`, add a dated `notes:` line (users exclude this category in bulk) |
+| Confirmation / identity link to click | `confirmation_required` | click it (or run `eraser confirm`) - no data change |
+| Bounce / dead address | `bounced` | `eraser mark-bounced <id>`, or set `email: ""` + dated note by hand. Never delete a real broker over a bounce - `MarkEmailUnreachable` in `internal/broker/broker.go` exists so the record survives for a later working address |
+| Refuses on a real statutory exemption (FCRA / GLBA / DPPA), genuine dead end | `rejected` | set `email: ""`, add a dated `notes:` line citing the basis; keep the row (see the `goodhire` entry) |
+
+"Remove the entry" vs. "blank the email" is a judgement call: delete when the
+company is genuinely not a broker and there's nothing to come back to; blank +
+note when they're a broker you just can't reach by email, or a dead end worth
+remembering.
+
+## Editing `data/brokers.yaml`
+
+- **Dated notes**: `notes: '<summary> (YYYY-MM-DD): <detail, quoting the reply where useful>'`. Append to an existing note rather than replacing its history.
+- **Commits**: one entry's worth of change per commit where practical, scoped `fix(brokers):` or `chore(brokers):`. Conventional Commits - release-please reads them.
+- **Generated files**: `site/content/brokers/**` and `site/static/brokers.json` are produced by `eraser guides` and git-ignored. Don't regenerate them for a data edit.
+- **Count floor**: after any add/remove, run `grep -c '^    - id:' data/brokers.yaml`. `README.md`, `docs/architecture.md`, and `EU-NOTES.md` all claim "750+" - keep the true count at or above 750 or fix those docs. `internal/broker` CI also fails below `MinSaneBrokerCount` (200).


### PR DESCRIPTION
## What

- **New doc `docs/broker-replies.md`** — a decision table mapping each broker email response type (keyed to `internal/inbox/classifier.go` `ResponseType`) to the right `data/brokers.yaml` edit, plus editing conventions (dated notes, the 750+ count floor, generated files). Registered in the CLAUDE.md docs map.
- **`data/brokers.yaml`** — actioned two replies received 2026-09-08:
  - Removed `crosswalk-technologies` (replied that they are not a data broker, hold no PII, aren't registered with any broker agencies).
  - `videoamp` — already `email: ""`; repointed `opt_out_url` at the form they named (`videoamp.com/your-privacy-choices/`) and recorded the email-not-accepted reply + toll-free number in `notes`.
  - Count 763 → 762, still above the "750+" floor.
- **`CLAUDE.md`** — added a Conventions section (Conventional Commits / release-please / branch-PR-squash) and a Recurring work section pointing at the doc that owns each repeat task.

## Verification

- `go build` / `go vet ./...` / `go test ./...` pass
- `./eraser validate-brokers data/brokers.yaml` → 762 brokers, exit 0
- `./eraser list-brokers --search crosswalk` empty; `--search videoamp` shows the new opt-out URL